### PR TITLE
Fix configuration example

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -25,7 +25,7 @@ For example::
 
 
     config = ConfigManager([
-        ConfigOSEnv,
+        ConfigOSEnv(),
         ConfigIniEnv([
             os.environ.get('FOO_INI'),
         ])


### PR DESCRIPTION
Tried the example and it failed because the ConfigOSEnv wasn't instantiated.