### PR TITLE
Fix return value for __call__; make NO_VALUE falsy

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -118,6 +118,15 @@ Some examples:
     this configuration variable isn't set anywhere, the result of this will be
     ``everett.NO_VALUE``.
 
+    .. Note::
+
+       ``everett.NO_VALUE`` is a falsy value so you can use it in comparative
+       contexts::
+
+           debug = config('DEBUG', parser=bool, raise_error=False)
+           if not debug:
+               pass
+
 ``config('debug', default='false', parser=bool)``
     The key is "debug".
 

--- a/everett/__init__.py
+++ b/everett/__init__.py
@@ -2,8 +2,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# NoValue instances are always false
+class NoValue(object):
+    def __nonzero__(self):
+        return False
+
+    def __bool__(self):
+        return False
+
+
 # Singleton indicating a non-value
-NO_VALUE = object()
+NO_VALUE = NoValue()
 
 
 # Configuration error indicator

--- a/everett/manager.py
+++ b/everett/manager.py
@@ -372,7 +372,8 @@ class ConfigManager(ConfigManagerBase):
             use this differently
         :arg default: the default value (if any); must be a string that is
             parseable by the specified parser; if no default is provided, this
-            will return ``everett.NO_VALUE``
+            will raise an error or return ``everett.NO_VALUE`` depending on
+            the value of ``raise_error``
         :arg parser: the parser for converting this value to a Python object
         :arg raise_error: True if you want a lack of value to raise a
             ``everett.ConfigurationError``
@@ -423,8 +424,8 @@ class ConfigManager(ConfigManagerBase):
                     key, namespace, parser)
             )
 
-        # Otherwise return None
-        return
+        # Otherwise return NO_VALUE
+        return NO_VALUE
 
 
 class ConfigOverride(object):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -21,6 +21,11 @@ from everett.manager import (
 )
 
 
+def test_no_value():
+    assert bool(NO_VALUE) is False
+    assert not NO_VALUE is True
+
+
 def test_parse_bool_error():
     with pytest.raises(ValueError):
         parse_bool('')
@@ -129,7 +134,7 @@ def test_ConfigIniEnv(datadir):
 def test_config():
     config = ConfigManager([])
 
-    assert config('DOESNOTEXISTNOWAY', raise_error=False) is None
+    assert config('DOESNOTEXISTNOWAY', raise_error=False) is NO_VALUE
     with pytest.raises(ConfigurationError):
         config('DOESNOTEXISTNOWAY')
     with pytest.raises(ConfigurationError):
@@ -141,7 +146,7 @@ def test_config_override():
     config = ConfigManager([])
 
     # Make sure the key doesn't exist
-    assert config('DOESNOTEXISTNOWAY', raise_error=False) is None
+    assert config('DOESNOTEXISTNOWAY', raise_error=False) is NO_VALUE
 
     # Try one override
     with config_override(DOESNOTEXISTNOWAY='bar'):


### PR DESCRIPTION
The documentation suggests that if raise_error is False, then __call__
will return NO_VALUE. However, the code was returning None. This fixes
that.

Further, this changes NO_VALUE so that it's falsy.