### PR TITLE
Implement get_namespace()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,9 @@ History
 Feature: Add ``ConfigManager.from_dict()`` shorthand for building configuration
 instances.
 
+Feature: Add ``.get_namespace()`` to ``ConfigManager`` and friends for getting
+the complete namespace for a given config instance as a list of strings.
+
 
 0.2 (August 16th, 2016)
 -----------------------

--- a/everett/manager.py
+++ b/everett/manager.py
@@ -404,6 +404,14 @@ class ConfigIniEnv(object):
 
 
 class ConfigManagerBase(object):
+    def get_namespace(self):
+        """Retrieves the complete namespace for this config object
+
+        :returns: namespace as a list of strings
+
+        """
+        return []
+
     def with_options(self, component):
         options = component.get_required_config()
         return BoundConfig(self, options)
@@ -426,6 +434,14 @@ class BoundConfig(ConfigManagerBase):
     def __init__(self, config, options):
         self.config = config
         self.options = options
+
+    def get_namespace(self):
+        """Retrieves the complete namespace for this config object
+
+        :returns: namespace as a list of strings
+
+        """
+        return self.config.get_namespace()
 
     def __call__(self, key, namespace=None, default=NO_VALUE, parser=str,
                  raise_error=True):
@@ -465,6 +481,14 @@ class NamespacedConfig(ConfigManagerBase):
     def __init__(self, config, namespace):
         self.config = config
         self.namespace = namespace
+
+    def get_namespace(self):
+        """Retrieves the complete namespace for this config object
+
+        :returns: namespace as a list of strings
+
+        """
+        return self.config.get_namespace() + [self.namespace]
 
     def __call__(self, key, namespace=None, default=NO_VALUE, parser=str,
                  raise_error=True):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -137,3 +137,31 @@ def test_parser_comes_from_options():
 
     comp = SomeComponent(config)
     assert comp.config('foo') == 1
+
+
+def test_get_namespace():
+    config = ConfigManager.from_dict({
+        'FOO': 'abc',
+        'FOO_BAR': 'abc',
+        'FOO_BAR_BAZ': 'abc',
+    })
+    assert config.get_namespace() == []
+
+    class SomeComponent(RequiredConfigMixin):
+        required_config = ConfigOptions()
+        required_config.add_option(
+            'foo',
+            parser=int
+        )
+
+        def __init__(self, config):
+            self.config = config.with_options(self)
+
+        def my_namespace_is(self):
+            return self.config.get_namespace()
+
+    comp = SomeComponent(config)
+    assert comp.my_namespace_is() == []
+
+    comp = SomeComponent(config.with_namespace('foo'))
+    assert comp.my_namespace_is() == ['foo']

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -269,3 +269,18 @@ def test_with_namespace():
     # Verify 'bat' is not available because it's not in the namespace
     with pytest.raises(ConfigurationError):
         config_with_namespace('bat')
+
+
+def test_get_namespace():
+    config = ConfigManager.from_dict({
+        'FOO': 'abc',
+        'FOO_BAR': 'abc',
+        'FOO_BAR_BAZ': 'abc',
+    })
+    assert config.get_namespace() == []
+
+    ns_foo_config = config.with_namespace('foo')
+    assert ns_foo_config.get_namespace() == ['foo']
+
+    ns_foo_bar_config = ns_foo_config.with_namespace('bar')
+    assert ns_foo_bar_config.get_namespace() == ['foo', 'bar']


### PR DESCRIPTION
This implements get_namespace() on the ConfigManager and friends. This
allows you to find out the full namespace for a given config object.

Fixes #18