### PR TITLE
Implement alternate_keys

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,14 @@ the complete namespace for a given config instance as a list of strings.
 
 Feature: Make ``ConfigDictEnv`` case-insensitive to keys and namespaces.
 
+Feature: Add ``alternate_keys`` to config call. This lets you specify a list
+of keys in order to try if the primary key doesn't find a value. This is
+helpful for deprecating keys that you used to use in a backwards-compatible
+way.
+
+Feature: Add ``root:`` prefix to keys allowing you to look outside of the
+current namespace and at the configuration root for configuration values.
+
 
 0.2 (August 16th, 2016)
 -----------------------

--- a/everett/component.py
+++ b/everett/component.py
@@ -24,13 +24,21 @@ class ConfigOptions(object):
     def __init__(self):
         self.options = OrderedDict()
 
-    def add_option(self, key, default=NO_VALUE, doc='', parser=str):
+    def add_option(self, key, default=NO_VALUE, alternate_keys=NO_VALUE,
+                   doc='', parser=str):
         """Adds an option to the group
 
         :arg key: the key to look up
+
         :arg default: the default value (if any); must be a string that is
             parseable by the specified parser
+
+        :arg alternate_keys: the list of alternate keys to look up;
+            supports a ``root:`` key prefix which will cause this to look at
+            the configuration root rather than the current namespace
+
         :arg doc: documentation for this config option
+
         :arg parser: the parser for converting this value to a Python object
 
         """

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -293,3 +293,40 @@ def test_get_namespace():
 
     ns_foo_bar_config = ns_foo_config.with_namespace('bar')
     assert ns_foo_bar_config.get_namespace() == ['foo', 'bar']
+
+
+@pytest.mark.parametrize('key,alternate_keys,expected', [
+    # key, alternate keys, expected
+    ('FOO', [], 'foo_abc'),
+    ('FOO', ['FOO_BAR'], 'foo_abc'),
+    ('BAD_KEY', ['FOO_BAR'], 'foo_bar_abc'),
+    ('BAD_KEY', ['BAD_KEY1', 'BAD_KEY2', 'FOO_BAR_BAZ'], 'foo_bar_baz_abc'),
+])
+def test_alternate_keys(key, alternate_keys, expected):
+    config = ConfigManager.from_dict({
+        'FOO': 'foo_abc',
+        'FOO_BAR': 'foo_bar_abc',
+        'FOO_BAR_BAZ': 'foo_bar_baz_abc',
+    })
+
+    assert config(key, alternate_keys=alternate_keys) == expected
+
+
+@pytest.mark.parametrize('key,alternate_keys,expected', [
+    # key, alternate keys, expected
+    ('BAR', [], 'foo_bar_abc'),
+    ('BAD_KEY', ['BAD_KEY1', 'BAR_BAZ'], 'foo_bar_baz_abc'),
+    ('bad_key', ['bad_key1', 'bar_baz'], 'foo_bar_baz_abc'),
+    ('bad_key', ['root:common_foo'], 'common_foo_abc')
+])
+def test_alternate_keys_with_namespace(key, alternate_keys, expected):
+    config = ConfigManager.from_dict({
+        'COMMON_FOO': 'common_foo_abc',
+        'FOO': 'foo_abc',
+        'FOO_BAR': 'foo_bar_abc',
+        'FOO_BAR_BAZ': 'foo_bar_baz_abc',
+    })
+
+    config = config.with_namespace('FOO')
+
+    assert config(key, alternate_keys=alternate_keys) == expected


### PR DESCRIPTION
This implements an alternate_keys config argument which lets you specify
a set of keys to check. This makes it possible to be backwards compatible
with configuration key changes.

Additionally, this adds handling for a special "root:" key prefix
which indicates to look at the root of the configuration rather than
in the current namespace. This makes it possible to allow for shared
configuration between components. For example, hosts, usernames and
passwords for services.

Fixes #19