### PR TITLE
Fix alternate_keys for components

### DIFF
--- a/everett/component.py
+++ b/everett/component.py
@@ -12,9 +12,10 @@ from everett import NO_VALUE
 
 
 class Option(object):
-    def __init__(self, key, default, doc, parser):
+    def __init__(self, key, default, alternate_keys, doc, parser):
         self.key = key
         self.default = default
+        self.alternate_keys = alternate_keys
         self.doc = doc
         self.parser = parser
 
@@ -42,7 +43,7 @@ class ConfigOptions(object):
         :arg parser: the parser for converting this value to a Python object
 
         """
-        option = Option(key, default, doc, parser)
+        option = Option(key, default, alternate_keys, doc, parser)
         self.options[key] = option
 
     def update(self, new_options):

--- a/everett/manager.py
+++ b/everett/manager.py
@@ -512,7 +512,7 @@ class BoundConfig(ConfigManagerBase):
             key,
             namespace=namespace,
             default=option.default,
-            alternate_keys=alternate_keys,
+            alternate_keys=option.alternate_keys,
             parser=option.parser,
             raise_error=raise_error
         )

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -165,3 +165,27 @@ def test_get_namespace():
 
     comp = SomeComponent(config.with_namespace('foo'))
     assert comp.my_namespace_is() == ['foo']
+
+
+def test_alternate_keys():
+    config = ConfigManager.from_dict({
+        'COMMON': 'common_abc',
+        'FOO': 'abc',
+        'FOO_BAR': 'abc',
+        'FOO_BAR_BAZ': 'abc',
+    })
+
+    class SomeComponent(RequiredConfigMixin):
+        required_config = ConfigOptions()
+        required_config.add_option(
+            'bad_key',
+            alternate_keys=['root:common']
+        )
+
+        def __init__(self, config):
+            self.config = config.with_options(self)
+
+    comp = SomeComponent(config)
+
+    # The key is invalid, so it tries the alternate keys
+    assert comp.config('bad_key') == 'common_abc'


### PR DESCRIPTION
Prior to this, alternate_keys was broken for components. It wasn't being
propagated correctly via .add_option().