### PR TITLE
Fix listify when passed None

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 0.4 (in development)
 --------------------
 
+Bug: Fix ``listify(None)`` to return ``[]``.
+
 
 0.3.1 (October 12th, 2016)
 --------------------------

--- a/everett/manager.py
+++ b/everett/manager.py
@@ -112,6 +112,8 @@ def listify(thing):
     :returns: list
 
     """
+    if thing is None:
+        return []
     if isinstance(thing, six.string_types):
         return [thing]
     return thing

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -35,13 +35,16 @@ def test_parse_bool_error():
         parse_bool('')
 
 
-def test_listify():
-    assert listify('foo') == ['foo']
-    assert listify('') == ['']
-
-    assert listify([]) == []
-    assert listify(['foo']) == ['foo']
-    assert listify(['foo', 'bar']) == ['foo', 'bar']
+@pytest.mark.parametrize('data,expected', [
+    (None, []),
+    ('', ['']),
+    ([], []),
+    ('foo', ['foo']),
+    (['foo'], ['foo']),
+    (['foo', 'bar'], ['foo', 'bar'])
+])
+def test_listify(data, expected):
+    assert listify(data) == expected
 
 
 @pytest.mark.parametrize('data', [


### PR DESCRIPTION
Prior to this fix, if you called listify(None), it'd return something
unhelpful. Now it returns the empty list.

The thinking here is that if listify gets None as an argument, it's
as if it got a string as an argument so we turn it into a list. But
None indicates no value--not a list of one value--so we turn it into
an empty list.