### PR TITLE
Add ConfigObjEnv

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -50,6 +50,13 @@ ConfigIniEnv
    :noindex:
 
 
+ConfigObjEnv
+------------
+
+.. autoclass:: everett.manager.ConfigObjEnv
+   :noindex:
+
+
 ConfigDictEnv
 -------------
 


### PR DESCRIPTION
Recently, I was working on a project that has multiple modes and it was
convenient to extend configuration to the command line. This pulls in
some generally-useful code to make that easier.

Fixes #36.