### PR TITLE
Improve error messages

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -89,8 +89,7 @@ specified.
 
 .. automethod:: everett.manager.ConfigManager.__call__
 
-
-Some examples:
+Some more examples:
 
 ``config('password')``
     The key is "password".
@@ -153,6 +152,62 @@ Some examples:
     it looks at "postgres_password" in the root namespace. This allows you to
     have multiple components that share configuration like credentials and
     hostnames.
+
+.. autoclass:: everett.ConfigurationError
+
+.. autoclass:: everett.InvalidValueError
+
+.. autoclass:: everett.ConfigurationMissingError
+
+.. autoclass:: everett.InvalidKeyError
+
+
+Handling exceptions when extracting values
+==========================================
+
+**In Python 3**
+
+    Getting configuration should always return a subclass of
+    :py:class:`everett.ConfigurationError`. This makes it easier to
+    programmatically figure out what happened.
+
+    Example:
+
+    .. code-block:: python
+
+       try:
+           some_val = config('debug_mode', parser=bool)
+       except ConfigurationError as ce:
+           # The "debug_mode" configuration value is incorrect--alert
+           # user in the logs.
+           logging.error(ce.message)
+           sys.exit(1)
+
+
+**In Python 2**
+
+    In Python 2, parsers can raise any kind of exception and Everett can't
+    wrap that nicely in a :py:class:`everett.ConfigurationError` without
+    losing information, so it doesn't try.
+
+    If you're using Python 2, you'll have to catch everything and
+
+    .. code-block:: python
+
+       try:
+           some_val = config('debug_mode', parser=bool)
+       except Exeption as exc:
+           # The "debug_mode" configuration value is probably
+           # incorrect--alert user in the logs.
+           logging.error(exc.message)
+           sys.exit(1)
+
+
+.. Note::
+
+   November 28th, 2016: This is irritating. If you have better ideas on how to
+   support Python 2 and 3, maintain the tracebacks, but yield a better exception
+   class, I'd love to know.
 
 
 Namespaces

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -171,17 +171,47 @@ Handling exceptions when extracting values
     :py:class:`everett.ConfigurationError`. This makes it easier to
     programmatically figure out what happened.
 
-    Example:
+    For example:
 
     .. code-block:: python
 
+       import logging
+
+       from everett import InvalidValueError
+       from everett.manager import ConfigManager
+
+       logging.basicConfig()
+
+       config = ConfigManager.from_dict({
+           'debug_mode': 'monkey'
+       })
+
        try:
            some_val = config('debug_mode', parser=bool)
-       except ConfigurationError as ce:
+       except InvalidValueError:
            # The "debug_mode" configuration value is incorrect--alert
            # user in the logs.
-           logging.error(ce.message)
-           sys.exit(1)
+           logging.exception('gah!')
+
+
+    That logs this::
+
+        ERROR:root:Gah!
+        Traceback (most recent call last):
+          File "/home/willkg/mozilla/everett/everett/manager.py", line 903, in __call__
+            return parser(val)
+          File "/home/willkg/mozilla/everett/everett/manager.py", line 109, in parse_bool
+            raise ValueError('"%s" is not a valid bool value' % val)
+          ValueError: "monkey" is not a valid bool value
+
+        During handling of the above exception, another exception occurred:
+
+        Traceback (most recent call last):
+          File "foo.py", line 13, in <module>
+            some_val = config('debug_mode', parser=bool)
+          File "/home/willkg/mozilla/everett/everett/manager.py", line 922, in __call__
+            raise InvalidValueError(msg)
+        everett.InvalidValueError: ValueError: "monkey" is not a valid bool value; namespace=None key=debug_mode requires a value parseable by everett.manager.parse_bool
 
 
 **In Python 2**
@@ -194,13 +224,40 @@ Handling exceptions when extracting values
 
     .. code-block:: python
 
+    For example:
+
+    .. code-block:: python
+
+       import logging
+
+       from everett.manager import ConfigManager
+
+       logging.basicConfig()
+
+       config = ConfigManager.from_dict({
+           'debug_mode': 'monkey'
+       })
+
        try:
            some_val = config('debug_mode', parser=bool)
-       except Exeption as exc:
+       except Exception:
            # The "debug_mode" configuration value is probably
-           # incorrect--alert user in the logs.
-           logging.error(exc.message)
-           sys.exit(1)
+           # incorrect, but it could be something else--alert user
+           # in the logs.
+           logging.exception('gah!')
+
+
+    This logs this::
+
+        ERROR:root:Gah!
+        Traceback (most recent call last):
+          File "foo.py", line 13, in <module>
+            some_val = config('debug_mode', parser=bool)
+          File "/home/willkg/mozilla/everett/everett/manager.py", line 903, in __call__
+            return parser(val)
+          File "/home/willkg/mozilla/everett/everett/manager.py", line 109, in parse_bool
+            raise ValueError('"%s" is not a valid bool value' % val)
+        ValueError: ValueError: "monkey" is not a valid bool value; namespace=None key=debug_mode requires a value parseable by everett.manager.parse_bool
 
 
 .. Note::

--- a/everett/__init__.py
+++ b/everett/__init__.py
@@ -19,8 +19,23 @@ class NoValue(object):
 NO_VALUE = NoValue()
 
 
-# Configuration error indicator
 class ConfigurationError(Exception):
+    """Configuration error base class"""
+    pass
+
+
+class ConfigurationMissingError(ConfigurationError):
+    """Indicates that required configuration is missing"""
+    pass
+
+
+class InvalidValueError(ConfigurationError):
+    """Indicates that the value is not valid"""
+    pass
+
+
+class InvalidKeyError(ConfigurationError):
+    """Indicates the key is not valid for this component"""
     pass
 
 

--- a/everett/manager.py
+++ b/everett/manager.py
@@ -124,12 +124,12 @@ def parse_env_file(envfile):
         if not line or line.startswith('#'):
             continue
         if '=' not in line:
-            raise ConfigurationError('Env file line missing = operator (line %s)' % line_no)
+            raise ConfigurationError('Env file line missing = operator (line %s)' % (line_no + 1))
         k, v = line.split('=', 1)
         k = k.strip()
         if not ENV_KEY_RE.match(k):
             raise ConfigurationError(
-                'Invalid variable name "%s" in env file (line %s)' % (k, line_no)
+                'Invalid variable name "%s" in env file (line %s)' % (k, (line_no + 1))
             )
         v = v.strip().strip('\'"')
         data[k] = v

--- a/everett/manager.py
+++ b/everett/manager.py
@@ -12,12 +12,19 @@ import importlib
 import inspect
 import os
 import re
+import sys
 import types
 
 from configobj import ConfigObj
 import six
 
-from everett import NO_VALUE, ConfigurationError
+from everett import (
+    ConfigurationError,
+    ConfigurationMissingError,
+    InvalidValueError,
+    InvalidKeyError,
+    NO_VALUE,
+)
 
 
 # This is a stack of overrides to be examined in reverse order
@@ -32,6 +39,8 @@ def qualname(thing):
     'str'
     >>> qualname(everett.manager.parse_class)
     'everett.manager.parse_class'
+    >>> qualname(everet.manager)
+    'everett.manager'
 
     """
     parts = []
@@ -44,6 +53,10 @@ def qualname(thing):
     # Python 3 has __qualname__--just use that if it's available
     if hasattr(thing, '__qualname__'):
         parts.append(thing.__qualname__)
+        return '.'.join(parts)
+
+    # If it's a module
+    if inspect.ismodule(thing):
         return '.'.join(parts)
 
     # If it's a class
@@ -93,7 +106,7 @@ def parse_bool(val):
     if val in false_vals:
         return False
 
-    raise ValueError('%s is not a valid bool value' % val)
+    raise ValueError('"%s" is not a valid bool value' % val)
 
 
 def parse_env_file(envfile):
@@ -106,17 +119,17 @@ def parse_env_file(envfile):
 
     """
     data = {}
-    for line in envfile:
+    for line_no, line in enumerate(envfile):
         line = line.strip()
         if not line or line.startswith('#'):
             continue
         if '=' not in line:
-            raise ConfigurationError('Env file line missing = operator')
+            raise ConfigurationError('Env file line missing = operator (line %s)' % line_no)
         k, v = line.split('=', 1)
         k = k.strip()
         if not ENV_KEY_RE.match(k):
             raise ConfigurationError(
-                'Invalid variable name %s in env file' % k
+                'Invalid variable name "%s" in env file (line %s)' % (k, line_no)
             )
         v = v.strip().strip('\'"')
         data[k] = v
@@ -135,8 +148,8 @@ def parse_class(val):
     try:
         return getattr(module, class_name)
     except AttributeError:
-        raise ValueError('%s is not a valid member of %s' % (
-            class_name, module)
+        raise ValueError('"%s" is not a valid member of %s' % (
+            class_name, qualname(module))
         )
 
 
@@ -670,7 +683,7 @@ class BoundConfig(ConfigManagerBase):
             option = self.options[key]
         except KeyError:
             if raise_error:
-                raise ConfigurationError(
+                raise InvalidKeyError(
                     '%s is not a valid key for this component' % (key,)
                 )
             return None
@@ -816,6 +829,20 @@ class ConfigManager(ConfigManagerBase):
         :arg raw_value: False if you wanted the parsed value, True if
             you want the raw value.
 
+        :raises everett.ConfigurationMissingError: if the required bit of configuration
+            is missing from all the environments
+
+        :raises everett.InvalidKeyError: if the configuration key doesn't exist for
+            that component
+
+        :raises everet.InvalidValueError: (Python 3-only) if the configuration value
+            is invalid in some way (not an integer, not a bool, etc)
+
+        :raises Exception subclass: (Python 2-only) parser code can raise
+            anything and since this is Python 2, we can't do much about it
+            without stomping on the traceback so we change the message and
+            raise the same exception
+
         Examples::
 
             config = ConfigManager([])
@@ -848,8 +875,8 @@ class ConfigManager(ConfigManagerBase):
             )
 
         if raw_value:
-            # If we're returning raw values, then we can just use str
-            # which is a no-op.
+            # If we're returning raw values, then we can just use str which is
+            # a no-op.
             parser = str
         else:
             parser = get_parser(parser)
@@ -872,17 +899,77 @@ class ConfigManager(ConfigManagerBase):
                 val = env.get(possible_key, use_namespace)
 
                 if val is not NO_VALUE:
-                    return parser(val)
+                    try:
+                        return parser(val)
+                    except ConfigurationError:
+                        # Re-raise ConfigurationError and friends since that's
+                        # what we want to be raising.
+                        raise
+                    except Exception as orig_exc:
+                        exc_info = sys.exc_info()
+                        msg = (
+                            '%s: %s; namespace=%s key=%s requires a value parseable by %s' % (
+                                exc_info[0].__name__,
+                                str(exc_info[1]),
+                                use_namespace,
+                                key,
+                                qualname(parser)
+                            )
+                        )
+
+                        if six.PY3:
+                            # Python 3 has exception chaining, so this is easy peasy
+                            raise InvalidValueError(msg)
+                        else:
+                            # Python 2 does not have exception chaining, so we're going
+                            # to break our promise that this always returns a
+                            # ConfigurationError, modify the message and then raise it
+                            # again.
+                            if orig_exc.args:
+                                orig_exc.args = tuple([msg] + list(orig_exc.args[1:]))
+                            else:
+                                orig_exc.args = tuple(msg)
+                            raise
 
         # Return the default if there is one
         if default is not NO_VALUE:
-            return parser(default)
+            try:
+                return parser(default)
+            except ConfigurationError:
+                # Re-raise ConfigurationError and friends since that's
+                # what we want to be raising.
+                raise
+            except Exception as orig_exc:
+                exc_info = sys.exc_info()
+                msg = (
+                    '%s: %s; namespace=%s key=%s requires a default value parseable by %s' % (
+                        exc_info[0].__name__,
+                        str(exc_info[1]),
+                        namespace,
+                        key,
+                        qualname(parser)
+                    )
+                )
+
+                if six.PY3:
+                    # Python 3 has exception chaining, so this is easy peasy
+                    raise InvalidValueError(msg)
+                else:
+                    # Python 2 does not have exception chaining, so we're going
+                    # to break our promise that this always returns a
+                    # ConfigurationError, modify the message and then raise it
+                    # again.
+                    if orig_exc.args:
+                        orig_exc.args = tuple([msg] + list(orig_exc.args[1:]))
+                    else:
+                        orig_exc.args = tuple(msg)
+                    raise
 
         # No value specified and no default, so raise an error to the user
         if raise_error:
-            raise ConfigurationError(
-                '%s (%s) requires a value parseable by %s' % (
-                    key, namespace, parser)
+            raise ConfigurationMissingError(
+                'namespace=%s key=%s requires a value parseable by %s' % (
+                    namespace, key, qualname(parser))
             )
 
         # Otherwise return NO_VALUE

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -6,8 +6,14 @@ import argparse
 import os
 
 import pytest
+import six
 
-from everett import NO_VALUE, ConfigurationError
+from everett import (
+    ConfigurationError,
+    InvalidValueError,
+    ConfigurationMissingError,
+    NO_VALUE,
+)
 from everett.manager import (
     ConfigDictEnv,
     ConfigEnvFileEnv,
@@ -84,6 +90,38 @@ def test_parse_bool_false(data):
     assert parse_bool(data) is False
 
 
+def test_parse_bool_with_config():
+    config = ConfigManager.from_dict({
+        'foo': 'bar'
+    })
+
+    # Test key is there, but value is bad
+    if six.PY3:
+        with pytest.raises(InvalidValueError) as excinfo:
+            config('foo', parser=bool)
+    else:
+        with pytest.raises(ValueError) as excinfo:
+            config('foo', parser=bool)
+    assert (
+        str(excinfo.value) ==
+        'ValueError: "bar" is not a valid bool value; namespace=None key=foo '
+        'requires a value parseable by everett.manager.parse_bool'
+    )
+
+    # Test key is not there and default is bad
+    if six.PY3:
+        with pytest.raises(InvalidValueError) as excinfo:
+            config('phil', default='foo', parser=bool)
+    else:
+        with pytest.raises(ValueError) as excinfo:
+            config('phil', default='foo', parser=bool)
+    assert (
+        str(excinfo.value) ==
+        'ValueError: "foo" is not a valid bool value; namespace=None key=phil '
+        'requires a default value parseable by everett.manager.parse_bool'
+    )
+
+
 def test_parse_missing_class():
     with pytest.raises(ImportError):
         parse_class('doesnotexist.class')
@@ -95,6 +133,43 @@ def test_parse_missing_class():
 def test_parse_class():
     from hashlib import md5
     assert parse_class('hashlib.md5') == md5
+
+
+def test_parse_class_config():
+    config = ConfigManager.from_dict({
+        'foo_class': 'hashlib.doesnotexist',
+        'bar_class': 'doesnotexist.class',
+    })
+
+    if six.PY3:
+        with pytest.raises(InvalidValueError) as exc_info:
+            config('foo_class', parser=parse_class)
+    else:
+        with pytest.raises(ValueError) as exc_info:
+            config('foo_class', parser=parse_class)
+    assert (
+        str(exc_info.value) ==
+        'ValueError: "doesnotexist" is not a valid member of hashlib; namespace=None key=foo_class '
+        'requires a value parseable by everett.manager.parse_class'
+    )
+
+    if six.PY3:
+        with pytest.raises(InvalidValueError) as exc_info:
+            config('bar_class', parser=parse_class)
+    else:
+        with pytest.raises(ImportError) as exc_info:
+            config('bar_class', parser=parse_class)
+    assert (
+        str(exc_info.value) in
+        [
+            # Python 2
+            'ImportError: No module named doesnotexist; namespace=None key=bar_class '
+            'requires a value parseable by everett.manager.parse_class',
+            # Python 3
+            'ImportError: No module named \'doesnotexist\'; namespace=None key=bar_class '
+            'requires a value parseable by everett.manager.parse_class',
+        ]
+    )
 
 
 def test_get_parser():
@@ -114,6 +189,24 @@ def test_ListOf():
     assert ListOf(bool)('t,f') == [True, False]
     assert ListOf(int)('1,2,3') == [1, 2, 3]
     assert ListOf(int, delimiter=':')('1:2') == [1, 2]
+
+
+def test_ListOf_error():
+    config = ConfigManager.from_dict({
+        'bools': 't,f,badbool'
+    })
+    if six.PY3:
+        with pytest.raises(InvalidValueError) as exc_info:
+            config('bools', parser=ListOf(bool))
+    else:
+        with pytest.raises(ValueError) as exc_info:
+            config('bools', parser=ListOf(bool))
+
+    assert (
+        str(exc_info.value) ==
+        'ValueError: "badbool" is not a valid bool value; namespace=None key=bools '
+        'requires a value parseable by <ListOf(bool)>'
+    )
 
 
 class TestConfigObjEnv:
@@ -244,12 +337,24 @@ def test_ConfigEnvFileEnv(datadir):
 
 def test_parse_env_file():
     assert parse_env_file(['PLAN9=outerspace']) == {'PLAN9': 'outerspace'}
-    with pytest.raises(ConfigurationError):
+    with pytest.raises(ConfigurationError) as exc_info:
         parse_env_file(['3AMIGOS=infamous'])
-    with pytest.raises(ConfigurationError):
+    assert (
+        str(exc_info.value) ==
+        'Invalid variable name "3AMIGOS" in env file (line 0)'
+    )
+    with pytest.raises(ConfigurationError) as exc_info:
         parse_env_file(['INVALID-CHAR=value'])
-    with pytest.raises(ConfigurationError):
+    assert (
+        str(exc_info.value) ==
+        'Invalid variable name "INVALID-CHAR" in env file (line 0)'
+    )
+    with pytest.raises(ConfigurationError) as exc_info:
         parse_env_file(['MISSING-equals'])
+    assert (
+        str(exc_info.value) ==
+        'Env file line missing = operator (line 0)'
+    )
 
 
 def test_get_key_from_envs():
@@ -280,11 +385,26 @@ def test_get_key_from_envs():
 def test_config():
     config = ConfigManager([])
 
+    # Don't raise an error and no default yields NO_VALUE
     assert config('DOESNOTEXISTNOWAY', raise_error=False) is NO_VALUE
-    with pytest.raises(ConfigurationError):
+
+    # Defaults to raising an error
+    with pytest.raises(ConfigurationMissingError) as exc_info:
         config('DOESNOTEXISTNOWAY')
-    with pytest.raises(ConfigurationError):
+    assert (
+        str(exc_info.value) ==
+        'namespace=None key=DOESNOTEXISTNOWAY requires a value parseable by str'
+    )
+
+    # Raises an error if raise_error is True
+    with pytest.raises(ConfigurationMissingError):
         config('DOESNOTEXISTNOWAY', raise_error=True)
+    assert (
+        str(exc_info.value) ==
+        'namespace=None key=DOESNOTEXISTNOWAY requires a value parseable by str'
+    )
+
+    # With a default, returns the default
     assert config('DOESNOTEXISTNOWAY', default='ohreally') == 'ohreally'
 
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -341,19 +341,19 @@ def test_parse_env_file():
         parse_env_file(['3AMIGOS=infamous'])
     assert (
         str(exc_info.value) ==
-        'Invalid variable name "3AMIGOS" in env file (line 0)'
+        'Invalid variable name "3AMIGOS" in env file (line 1)'
     )
     with pytest.raises(ConfigurationError) as exc_info:
         parse_env_file(['INVALID-CHAR=value'])
     assert (
         str(exc_info.value) ==
-        'Invalid variable name "INVALID-CHAR" in env file (line 0)'
+        'Invalid variable name "INVALID-CHAR" in env file (line 1)'
     )
     with pytest.raises(ConfigurationError) as exc_info:
-        parse_env_file(['MISSING-equals'])
+        parse_env_file(['', 'MISSING-equals'])
     assert (
         str(exc_info.value) ==
-        'Env file line missing = operator (line 0)'
+        'Env file line missing = operator (line 2)'
     )
 
 


### PR DESCRIPTION
Error messages need to be informative to the programmer and the user in
regards to what happened and what should be done about it.

This improves error messages so it's clearer which are due to
configuration value problems and how to figure out how to fix them.

Fixes #33