### PR TITLE
Implement get_runtime_config

### DIFF
--- a/docs/components.rst
+++ b/docs/components.rst
@@ -93,6 +93,21 @@ declaration for auto-documenting configuration for components.
 .. automodule:: everett.sphinx_autoconfig
 
 
+Getting configuration information for components
+================================================
+
+The :py:class:`everett.component.RequiredConfigMixin` has two methods to pull
+configuration about the component.
+
+:py:meth:`everett.component.RequiredConfigMixin.get_required_config` will
+return the required configuration for that component. This follows class
+hierarchies, handles configuration overrides and other things like that. The
+final :py:class:`everett.component.ConfigOptions` class that you get is the
+configuration for that component.
+
+See :py:class:`everett.component.RequiredConfigMixin` for more details.
+
+
 Recipes
 =======
 

--- a/everett/component.py
+++ b/everett/component.py
@@ -132,9 +132,11 @@ class RequiredConfigMixin(object):
 
         .. Note::
 
-           If you this instance has a ``.config`` attribute and that is a
+           If this instance has a ``.config`` attribute and it is a
            :py:class:`everett.component.BoundConfig`, then this will try to
            compute the runtime config.
+
+           Otherwise, it'll yield nothing.
 
         :arg list namespace: list of namespace parts or None
 


### PR DESCRIPTION
This allows you to roll up the run time configuration for a tree of
components. This helps immensely when logging configuration at startup
or generating INI files or anything along those lines.

Fixes #35