### PR TITLE
Redo sphinx extension

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,16 @@
 History
 =======
 
+0.9 (in development)
+--------------------
+
+Feature: Rewrite Sphinx extension. The extension is now in the
+``everett.sphinxext`` module and the directive is now ``.. autocomponent::``. It
+generates better documentation and it now indexes Everett components.
+
+Documentation fixes and updates.
+
+
 0.8 (January 24th, 2017)
 ------------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,9 +4,17 @@ History
 0.9 (in development)
 --------------------
 
-Feature: Rewrite Sphinx extension. The extension is now in the
-``everett.sphinxext`` module and the directive is now ``.. autocomponent::``. It
-generates better documentation and it now indexes Everett components.
+Changed:
+
+* Rewrite Sphinx extension. The extension is now in the ``everett.sphinxext``
+  module and the directive is now ``.. autocomponent::``. It generates better
+  documentation and it now indexes Everett components.
+
+* Changed the ``HISTORY.rst`` structure.
+
+Fixed:
+
+* Fix an example in the docs where the final key was backwards. Thank you, pjz!
 
 Documentation fixes and updates.
 
@@ -14,11 +22,12 @@ Documentation fixes and updates.
 0.8 (January 24th, 2017)
 ------------------------
 
-Feature: Add ``:namespace:`` and ``:case:`` arguments to autoconfig
-directive. These make it easier to cater your documentation to your
-project's needs.
+Added:
 
-Feature: Add support for Python 3.6.
+* Add ``:namespace:`` and ``:case:`` arguments to autoconfig directive. These
+  make it easier to cater your documentation to your project's needs.
+
+* Add support for Python 3.6.
 
 Minor documentation fixes and updates.
 
@@ -26,13 +35,16 @@ Minor documentation fixes and updates.
 0.7 (January 5th, 2017)
 -----------------------
 
-Feature: You can now include documentation hints and urls for
-``ConfigManager`` objects and config options. This will make it easier
-for your users to debug configuration errors they're having with your
-software.
+Added:
 
-Bug: Fix ``ListOf`` so it returns empty lists rather than a list with
-a single empty string.
+* Feature: You can now include documentation hints and urls for
+  ``ConfigManager`` objects and config options. This will make it easier for
+  your users to debug configuration errors they're having with your software.
+
+Fixed:
+
+* Fix ``ListOf`` so it returns empty lists rather than a list with a single
+  empty string.
 
 Documentation fixes and updates.
 
@@ -40,23 +52,26 @@ Documentation fixes and updates.
 0.6 (November 28th, 2016)
 -------------------------
 
-Feature: Change ``:show-docstring:`` to take an optional value which is the
-attribute to pull docstring content from. This means you don't have to mix
-programming documentation with user documentation--they can be in different
-attributes.
+Added:
 
-Feature: Add ``RequiredConfigMixin.get_runtime_config()`` which returns the
-runtime configuration for a component or tree of components. This lets you print
-runtime configuration at startup, generate INI files, etc.
+* Add ``RequiredConfigMixin.get_runtime_config()`` which returns the runtime
+  configuration for a component or tree of components. This lets you print
+  runtime configuration at startup, generate INI files, etc.
 
-Feature: Add ``ConfigObjEnv`` which lets you use an object for configuration.
-This works with argparse's Namespace amongst other things.
+* Add ``ConfigObjEnv`` which lets you use an object for configuration. This
+  works with argparse's Namespace amongst other things.
 
-Feature: Improve configuration-related exceptions. With Python 3, configuration
-errors all derive from ``ConfigurationError`` and have helpful error messages
-that should make it clear what's wrong with the configuration value. With Python
-2, you can get other kinds of Exceptions thrown depending on the parser used,
-but configuration error messages should still be helpful.
+Changed:
+
+* Change ``:show-docstring:`` to take an optional value which is the attribute
+  to pull docstring content from. This means you don't have to mix programming
+  documentation with user documentation--they can be in different attributes.
+
+* Improve configuration-related exceptions. With Python 3, configuration errors
+  all derive from ``ConfigurationError`` and have helpful error messages that
+  should make it clear what's wrong with the configuration value. With Python 2,
+  you can get other kinds of Exceptions thrown depending on the parser used, but
+  configuration error messages should still be helpful.
 
 Documentation fixes and updates.
 
@@ -64,25 +79,36 @@ Documentation fixes and updates.
 0.5 (November 8th, 2016)
 ------------------------
 
-Feature: Add ``:show-docstring:`` flag to ``autoconfig`` directive.
+Added:
 
-Feature: Add ``:hide-classname:`` flag to ``autoconfig`` directive.
+* Add ``:show-docstring:`` flag to ``autoconfig`` directive.
 
-Feature: Rewrite ``ConfigIniEnv`` to use configobj which allows for nested
-sections in INI files. This also allows you to specify multiple INI files
-and have later ones override earlier ones.
+* Add ``:hide-classname:`` flag to ``autoconfig`` directive.
 
-Bug: Fix ``autoconfig`` Sphinx directive and add tests--it was all kinds of
-broken.
+Changed:
+
+* Rewrite ``ConfigIniEnv`` to use configobj which allows for nested sections in
+  INI files. This also allows you to specify multiple INI files and have later
+  ones override earlier ones.
+
+Fixed:
+
+* Fix ``autoconfig`` Sphinx directive and add tests--it was all kinds of broken.
+
+Documentation fixes and updates.
 
 
 0.4 (October 27th, 2016)
 ------------------------
 
-Feature: Add ``raw_value`` argument to config calls. This makes it easier to
-write code that prints configuration.
+Added:
 
-Bug: Fix ``listify(None)`` to return ``[]``.
+* Add ``raw_value`` argument to config calls. This makes it easier to write code
+  that prints configuration.
+
+Fixed:
+
+* Fix ``listify(None)`` to return ``[]``.
 
 Documentation fixes and updates.
 
@@ -90,45 +116,59 @@ Documentation fixes and updates.
 0.3.1 (October 12th, 2016)
 --------------------------
 
-Bug: Fix ``alternate_keys`` with components. Previously it worked for everything
-but components. Now it works with components, too.
+Fixed:
+
+* Fix ``alternate_keys`` with components. Previously it worked for everything
+  but components. Now it works with components, too.
+
+Documentation fixes and updates.
 
 
 0.3 (October 6th, 2016)
 -----------------------
 
-Feature: Add ``ConfigManager.from_dict()`` shorthand for building configuration
-instances.
+Added:
 
-Feature: Add ``.get_namespace()`` to ``ConfigManager`` and friends for getting
-the complete namespace for a given config instance as a list of strings.
+* Add ``ConfigManager.from_dict()`` shorthand for building configuration
+  instances.
 
-Feature: Make ``ConfigDictEnv`` case-insensitive to keys and namespaces.
+* Add ``.get_namespace()`` to ``ConfigManager`` and friends for getting
+  the complete namespace for a given config instance as a list of strings.
 
-Feature: Add ``alternate_keys`` to config call. This lets you specify a list
-of keys in order to try if the primary key doesn't find a value. This is
-helpful for deprecating keys that you used to use in a backwards-compatible
-way.
+* Add ``alternate_keys`` to config call. This lets you specify a list of keys in
+  order to try if the primary key doesn't find a value. This is helpful for
+  deprecating keys that you used to use in a backwards-compatible way.
 
-Feature: Add ``root:`` prefix to keys allowing you to look outside of the
-current namespace and at the configuration root for configuration values.
+* Add ``root:`` prefix to keys allowing you to look outside of the current
+  namespace and at the configuration root for configuration values.
+
+Changed:
+
+* Make ``ConfigDictEnv`` case-insensitive to keys and namespaces.
+
+Documentation fixes and updates.
 
 
 0.2 (August 16th, 2016)
 -----------------------
 
-Feature: Add ``ConfigEnvFileEnv`` for supporting ``.env`` files. Thank you,
-Paul!
+Added:
 
-Feature: Change ``ConfigIniEnv`` to take a single path or list of paths. Thank
-you, Paul!
+* Add ``ConfigEnvFileEnv`` for supporting ``.env`` files. Thank you, Paul!
 
-Feature: Add "on" and "off" as valid boolean values. This makes it easier to use
-config for feature flippers. Thank you, Paul!
+* Add "on" and "off" as valid boolean values. This makes it easier to use config
+  for feature flippers. Thank you, Paul!
 
-Feature: Make ``NO_VALUE`` falsy.
+Changed:
 
-Bug: Fix ``__call__`` returning None--it should return ``NO_VALUE``.
+* Change ``ConfigIniEnv`` to take a single path or list of paths. Thank you,
+  Paul!
+
+* Make ``NO_VALUE`` falsy.
+
+Fixed:
+
+* Fix ``__call__`` returning None--it should return ``NO_VALUE``.
 
 Lots of docs updates: finished the section about making your own parsers, added
 a section on using dj-database-url, added a section on django-cache-url and

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Configuration with Everett:
 * supports key namespaces
 * facilitates writing tests that change configuration values
 * supports component architectures with auto-documentation of configuration with
-  a Sphinx ``autoconfig`` directive
+  a Sphinx ``autocomponent`` directive
 
 Everett is inspired by `python-decouple
 <https://github.com/henriquebastos/python-decouple>`_ and `configman
@@ -159,7 +159,7 @@ In your environment, you would provide ``RMQ_HOST``, etc for this component.
 You can auto-document the configuration for this component in your Sphinx docs
 with::
 
-    .. autoconfig:: path.to.RabbitMQComponent
+    .. autocomponent:: path.to.RabbitMQComponent
 
 
 Say your app actually needs to connect to two separate queues--one for regular

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -81,18 +81,6 @@ In our environment, we provide the regular queue configuration with
 Same component code--two different instances.
 
 
-Documenting components
-======================
-
-Components can have configuration. It's important to be able to easily document
-this configuration.
-
-As such, Everett includes a Sphinx extension that adds a ``autoconfig``
-declaration for auto-documenting configuration for components.
-
-.. automodule:: everett.sphinx_autoconfig
-
-
 Getting configuration information for components
 ================================================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Contents
    history
    configuration
    components
+   sphinxext
    recipes
    library
    dev

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -37,8 +37,8 @@ for the application:
 
 
 Couple of nice things here. First, is that if you do Sphinx documentation, you
-can use ``autoconfig`` to automatically document your configuration based on the
-code. Second, you can use
+can use ``autocomponent`` to automatically document your configuration based on
+the code. Second, you can use
 :py:meth:`everett.component.RequiredConfigMixin.get_runtime_config` to print out
 the runtime configuratino at startup.
 

--- a/docs/sphinxext.rst
+++ b/docs/sphinxext.rst
@@ -1,0 +1,22 @@
+==========================
+Using the Sphinx extension
+==========================
+
+No one likes to spend hours updating configuration documentation.
+
+No one likes to spend hours trying to get something to work only to discover the
+configuration documentation is out of date, missing important information, or
+just wrong.
+
+Blech.
+
+Everett comes with a `Sphinx <https://http://www.sphinx-doc.org/en/stable/>`_
+extension to make it easier to document Everett components and configuration.
+This allows you to write configuration code and have it automatically documented
+in your Sphinx-generated docs without having to manually update it.
+
+Further, Everett components will show up in the index making it easier for users
+to find what they're looking for.
+
+
+.. automodule:: everett.sphinxext

--- a/everett/__init__.py
+++ b/everett/__init__.py
@@ -43,6 +43,6 @@ __author__ = 'Will Kahn-Greene'
 __email__ = 'willkg@mozilla.com'
 
 # yyyymmdd
-__releasedate__ = '20170124'
+__releasedate__ = ''
 # x.y or x.y.dev
-__version__ = '0.8'
+__version__ = '0.9.dev'


### PR DESCRIPTION
* change module name to everett/sphinxext.py
* change auto directive to autocomponent
* add an everett domain and a everett:component directive
* change options to be done with TypedField

This cleans up the sphinx extension significantly and puts us on track to having
it indexed and show up more helpfully in documentation.

Fixes #51.