### PR TITLE
Add options to the index

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Changed:
 
 * Rewrite Sphinx extension. The extension is now in the ``everett.sphinxext``
   module and the directive is now ``.. autocomponent::``. It generates better
-  documentation and it now indexes Everett components.
+  documentation and it now indexes Everett components and options.
 
 * Changed the ``HISTORY.rst`` structure.
 


### PR DESCRIPTION
This adds options to the index by adding an index section before adding the
everett:component directive. In doing that, options show up in the index and
point to the component documentation.

This is easier to do than making options an object type which would mean I'd
have to do my own formatting (can't really use TypedField) and some other things
also get harder.

Fixes #61.