### PR TITLE
Fixed list parsing from ConfigIniEnv and adjusted code to match docs.

### DIFF
--- a/everett/manager.py
+++ b/everett/manager.py
@@ -600,11 +600,11 @@ class ConfigIniEnv(object):
 
             path = os.path.abspath(os.path.expanduser(path.strip()))
             if path and os.path.isfile(path):
-                self.cfg.update(ConfigIniEnv.parse_ini_file(path))
+                self.cfg.update(self.parse_ini_file(path))
+                break
 
-    @classmethod
     def parse_ini_file(cls, path):
-        cfgobj = ConfigObj(path)
+        cfgobj = ConfigObj(path, list_values=False)
 
         def extract_section(namespace, d):
             cfg = {}

--- a/tests/data/config_test.ini
+++ b/tests/data/config_test.ini
@@ -1,5 +1,6 @@
 [main]
 foo = bar
+bar = test1,test2
 
 [nsbaz]
 foo = bat

--- a/tests/data/config_test_original.ini
+++ b/tests/data/config_test_original.ini
@@ -1,0 +1,2 @@
+[main]
+foo_original = original

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -318,6 +318,23 @@ def test_ConfigIniEnv(datadir):
     assert cie.get('foo') == NO_VALUE
 
 
+def test_ConfigIniEnv_multiple_files(datadir):
+    ini_filename = os.path.join(datadir, 'config_test.ini')
+    ini_filename_original = os.path.join(datadir, 'config_test_original.ini')
+    cie = ConfigIniEnv([ini_filename, ini_filename_original])
+    # Only the first found file is loaded, so foo_original does not exist
+    assert cie.get('foo_original') == NO_VALUE
+    cie = ConfigIniEnv([ini_filename_original])
+    # ... but it is there if only the original is loaded (safety check)
+    assert cie.get('foo_original') == 'original'
+
+
+def test_ConfigIniEnv_does_not_parse_lists(datadir):
+    ini_filename = os.path.join(datadir, 'config_test.ini')
+    cie = ConfigIniEnv([ini_filename])
+    assert cie.get('bar') == 'test1,test2'
+
+
 def test_ConfigEnvFileEnv(datadir):
     env_filename = os.path.join(datadir, '.env')
     cefe = ConfigEnvFileEnv(['/does/not/exist/.env', env_filename])


### PR DESCRIPTION
Hi there; this is a small patch (with tests) that brings the behavior of `ConfigIniEnv` in line with other variants. What do you think?