### PR TITLE
Update dev requirements and fix warnings

### DIFF
--- a/everett/sphinxext.py
+++ b/everett/sphinxext.py
@@ -134,7 +134,7 @@ from docutils.statemachine import ViewList
 from sphinx import addnodes
 from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, ObjType
-from sphinx.locale import l_, _
+from sphinx.locale import _
 from sphinx.roles import XRefRole
 from sphinx.util.docfields import TypedField
 from sphinx.util.docstrings import prepare_docstring
@@ -182,7 +182,7 @@ class EverettComponent(ObjectDescription):
     """
 
     doc_field_types = [
-        TypedField('options', label=l_('Options'),
+        TypedField('options', label=_('Options'),
                    names=('option', 'opt'),
                    typerolename='obj', typenames=('parser',),
                    can_collapse=True),
@@ -244,7 +244,7 @@ class EverettDomain(Domain):
     label = 'Everett'
 
     object_types = {
-        'component': ObjType(l_('component'), 'comp'),
+        'component': ObjType(_('component'), 'comp'),
     }
     directives = {
         'component': EverettComponent,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 -e .
 
-pytest==3.0.7
+pytest==4.0.2
 pytest-wholenodeid==0.2
-tox==2.6
-twine==1.8.1
-Sphinx==1.5.5
-flake8==3.3.0
+tox==3.6.1
+twine==1.12.1
+Sphinx==1.8.3
+flake8==3.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,10 @@ universal=1
 
 [flake8]
 max-line-length = 100
+
+[tool:pytest]
+filterwarnings =
+    error
+    ignore:::babel[.*]
+    ignore:::docutils[.*]
+    ignore:::jinja2[.*]


### PR DESCRIPTION
This adjusts pytest to make all warnings errors except for ones that are in
other libraries.

Fixes #76