### PR TITLE
Change ConfigIniEnv to require an optional requirement

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,10 +11,24 @@ Backwards incompatible changes:
 
 * Dropped support for Python 2.7. (#73)
 
+* Moved ``ConfigIniEnv`` to a different module. Now you need to import it
+  like this::
+
+      from everett.ext.inifile import ConfigIniEnv
+
+  (#79)
+
 Features:
 
 
 Fixes:
+
+* Everett no longer requires ``configobj``--it's now optional. If you use
+  ``ConfigIniEnv``, you can install it with::
+
+      $ pip install everett[ini]
+
+  (#79)
 
 * Fixed list parsing and file discovery in ConfigIniEnv so they match the
   docs and are more consistent with other envs. Thank you, apollo13! (#71)

--- a/README.rst
+++ b/README.rst
@@ -326,6 +326,11 @@ Run::
 
     $ pip install everett
 
+If you want to use the ``ConfigIniEnv``, you need to install its requirements
+as well::
+
+    $ pip install everett[ini]
+
 
 Install for hacking
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -89,12 +89,18 @@ We want to pull infrastructure values from the environment.
 
 Values from the environment should override values from the INI file.
 
-First, we set up our ``ConfigManager``::
+First, we need to install the additional requirements for INI file
+environments::
+
+    pip install everett[ini]
+
+Then we set up our ``ConfigManager``::
 
     import os
     import sys
 
-    from everett.manager import ConfigManager, ConfigOSEnv, ConfigIniEnv
+    from everett.ext.inifile import ConfigIniEnv
+    from everett.manager import ConfigManager, ConfigOSEnv
 
 
     def get_config():
@@ -172,7 +178,8 @@ First, create a configuration class::
     import sys
 
     from everett.component import RequiredConfigMixin, ConfigOptions
-    from everett.manager import ConfigManager, ConfigOSEnv, ConfigIniEnv
+    from everett.ext.inifile import ConfigIniEnv
+    from everett.manager import ConfigManager, ConfigOSEnv
 
 
     class AppConfig(RequiredConfigMixin):

--- a/docs/code/configuration_sources.py
+++ b/docs/code/configuration_sources.py
@@ -1,7 +1,7 @@
 import os
+from everett.ext.inifile import ConfigIniEnv
 from everett.manager import (
     ConfigDictEnv,
-    ConfigIniEnv,
     ConfigManager,
     ConfigOSEnv
 )

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -104,7 +104,7 @@ ConfigEnvFileEnv
 ConfigIniEnv
 ------------
 
-.. autoclass:: everett.manager.ConfigIniEnv
+.. autoclass:: everett.ext.inifile.ConfigIniEnv
    :noindex:
 
 

--- a/everett/__init__.py
+++ b/everett/__init__.py
@@ -3,6 +3,15 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
+__author__ = 'Will Kahn-Greene'
+__email__ = 'willkg@mozilla.com'
+
+# yyyymmdd
+__releasedate__ = ''
+# x.y or x.y.dev0
+__version__ = '1.0.dev0'
+
+
 # NoValue instances are always false
 class NoValue(object):
     def __nonzero__(self):
@@ -49,12 +58,3 @@ class ConfigurationMissingError(DetailedConfigurationError):
 class InvalidValueError(DetailedConfigurationError):
     """Indicates that the value is not valid"""
     pass
-
-
-__author__ = 'Will Kahn-Greene'
-__email__ = 'willkg@mozilla.com'
-
-# yyyymmdd
-__releasedate__ = ''
-# x.y or x.y.dev0
-__version__ = '1.0.dev0'

--- a/everett/ext/__init__.py
+++ b/everett/ext/__init__.py
@@ -1,0 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Holds env files that have other requirements
+
+"""

--- a/everett/manager.py
+++ b/everett/manager.py
@@ -15,8 +15,6 @@ import re
 import sys
 import types
 
-from configobj import ConfigObj
-
 from everett import (
     ConfigurationError,
     ConfigurationMissingError,
@@ -28,6 +26,8 @@ from everett import (
 
 # This is a stack of overrides to be examined in reverse order
 _CONFIG_OVERRIDE = []
+
+# Regex for valid keys in an env file
 ENV_KEY_RE = re.compile(r'^[a-z][a-z0-9_]*$', flags=re.IGNORECASE)
 
 
@@ -50,7 +50,7 @@ def qualname(thing):
     if mod and mod.__name__ not in ('__main__', '__builtin__', 'builtins'):
         parts.append(mod.__name__)
 
-    # Python 3 has __qualname__--just use that if it's available
+    # If there's a __qualname__, use that
     if hasattr(thing, '__qualname__'):
         parts.append(thing.__qualname__)
         return '.'.join(parts)
@@ -496,131 +496,6 @@ class ConfigOSEnv(object):
     """
     def get(self, key, namespace=None):
         return get_key_from_envs(os.environ, key, namespace)
-
-
-class ConfigIniEnv(object):
-    """Source for pulling configuration from INI files
-
-    Takes a path or list of possible paths to look for the INI file and uses
-    the first one it finds.
-
-    If it finds no INI files in the possible paths, then this configuration
-    source will be a no-op.
-
-    This will expand ``~`` as well as work relative to the current working
-    directory.
-
-    This example looks just for the INI file specified in the environment::
-
-        from everett.manager import ConfigIniEnv, ConfigManager
-
-        config = ConfigManager([
-            ConfigIniEnv(os.environ.get('FOO_INI'))
-        ])
-
-
-    If there's no ``FOO_INI`` in the environment, then the path will be
-    ignored.
-
-    Here's an example that looks for the INI file specified in the environment
-    variable ``FOO_INI`` and failing that will look for ``.antenna.ini`` in the
-    user's home directory::
-
-        from everett.manager import ConfigIniEnv, ConfigManager
-
-        config = ConfigManager([
-            ConfigIniEnv([
-                os.environ.get('FOO_INI'),
-                '~/.antenna.ini'
-            ])
-        ])
-
-
-    This example looks for a ``config/local.ini`` file which overrides values
-    in a ``config/base.ini`` file both are relative to the current working
-    directory::
-
-        from everett.manager import ConfigIniEnv, ConfigManager
-
-        config = ConfigManager([
-            ConfigIniEnv('config/local.ini'),
-            ConfigIniEnv('config/base.ini')
-        ])
-
-
-    Note how you can have multiple ``ConfigIniEnv`` files and this is how you
-    can set Everett up to have values in one INI file override values in
-    another INI file.
-
-    INI files must have a "main" section. This is where keys that aren't in a
-    namespace are placed.
-
-    Minimal INI file::
-
-        [main]
-
-
-    In the INI file, namespace is a section. So key "user" in namespace "foo"
-    is::
-
-        [foo]
-        user=someval
-
-
-    Everett uses configobj, so it supports nested sections like this::
-
-        [main]
-        foo=bar
-
-        [namespace]
-        foo2=bar2
-
-          [[namespace2]]
-          foo3=bar3
-
-
-    Which gives you these:
-
-    * ``FOO``
-    * ``NAMESPACE_FOO2``
-    * ``NAMESPACE_NAMESPACE2_FOO3``
-
-    See more details here:
-    http://configobj.readthedocs.io/en/latest/configobj.html#the-config-file-format
-
-    """
-    def __init__(self, possible_paths):
-        self.cfg = {}
-        possible_paths = listify(possible_paths)
-
-        for path in possible_paths:
-            if not path:
-                continue
-
-            path = os.path.abspath(os.path.expanduser(path.strip()))
-            if path and os.path.isfile(path):
-                self.cfg.update(self.parse_ini_file(path))
-                break
-
-    def parse_ini_file(self, path):
-        cfgobj = ConfigObj(path, list_values=False)
-
-        def extract_section(namespace, d):
-            cfg = {}
-            for key, val in d.items():
-                if isinstance(d[key], dict):
-                    cfg.update(extract_section(namespace + [key], d[key]))
-                else:
-                    cfg['_'.join(namespace + [key]).upper()] = val
-
-            return cfg
-
-        return extract_section([], cfgobj.dict())
-
-    def get(self, key, namespace=None):
-        # The "main" section is considered the root mainspace.
-        namespace = namespace or ['main']
-        return get_key_from_envs(self.cfg, key, namespace)
 
 
 class ConfigManagerBase(object):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
--e .
+-e .[ini]
 
 pytest==4.0.2
 pytest-wholenodeid==0.2

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,10 @@ setup(
     author="Will Kahn-Greene",
     author_email='willkg@mozilla.com',
     url='https://github.com/willkg/everett',
-    install_requires=[
-        'configobj',
-    ],
+    install_requires=[],
+    extras_require={
+        'ini': ['configobj'],
+    },
     packages=[
         'everett',
     ],

--- a/tests/ext/test_inifile.py
+++ b/tests/ext/test_inifile.py
@@ -1,0 +1,37 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+
+from everett import NO_VALUE
+from everett.ext.inifile import ConfigIniEnv
+
+
+class TestConfigIniEnv:
+    def test_basic_usage(self, datadir):
+        ini_filename = os.path.join(datadir, 'config_test.ini')
+        cie = ConfigIniEnv([ini_filename])
+        assert cie.get('foo') == 'bar'
+        assert cie.get('FOO') == 'bar'
+        assert cie.get('foo', namespace='nsbaz') == 'bat'
+        assert cie.get('foo', namespace=['nsbaz']) == 'bat'
+        assert cie.get('foo', namespace=['nsbaz', 'nsbaz2']) == 'bat2'
+
+        cie = ConfigIniEnv(['/a/b/c/bogus/filename'])
+        assert cie.get('foo') == NO_VALUE
+
+    def test_multiple_files(self, datadir):
+        ini_filename = os.path.join(datadir, 'config_test.ini')
+        ini_filename_original = os.path.join(datadir, 'config_test_original.ini')
+        cie = ConfigIniEnv([ini_filename, ini_filename_original])
+        # Only the first found file is loaded, so foo_original does not exist
+        assert cie.get('foo_original') == NO_VALUE
+        cie = ConfigIniEnv([ini_filename_original])
+        # ... but it is there if only the original is loaded (safety check)
+        assert cie.get('foo_original') == 'original'
+
+    def test_does_not_parse_lists(self, datadir):
+        ini_filename = os.path.join(datadir, 'config_test.ini')
+        cie = ConfigIniEnv([ini_filename])
+        assert cie.get('bar') == 'test1,test2'

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -16,7 +16,6 @@ from everett import (
 from everett.manager import (
     ConfigDictEnv,
     ConfigEnvFileEnv,
-    ConfigIniEnv,
     ConfigManager,
     ConfigOSEnv,
     ConfigObjEnv,
@@ -279,36 +278,6 @@ def test_ConfigOSEnv():
     assert cose.get('everett_test_foo') == 'bar'
     assert cose.get('EVERETT_test_foo') == 'bar'
     assert cose.get('foo', namespace=['everett', 'test']) == 'bar'
-
-
-def test_ConfigIniEnv(datadir):
-    ini_filename = os.path.join(datadir, 'config_test.ini')
-    cie = ConfigIniEnv([ini_filename])
-    assert cie.get('foo') == 'bar'
-    assert cie.get('FOO') == 'bar'
-    assert cie.get('foo', namespace='nsbaz') == 'bat'
-    assert cie.get('foo', namespace=['nsbaz']) == 'bat'
-    assert cie.get('foo', namespace=['nsbaz', 'nsbaz2']) == 'bat2'
-
-    cie = ConfigIniEnv(['/a/b/c/bogus/filename'])
-    assert cie.get('foo') == NO_VALUE
-
-
-def test_ConfigIniEnv_multiple_files(datadir):
-    ini_filename = os.path.join(datadir, 'config_test.ini')
-    ini_filename_original = os.path.join(datadir, 'config_test_original.ini')
-    cie = ConfigIniEnv([ini_filename, ini_filename_original])
-    # Only the first found file is loaded, so foo_original does not exist
-    assert cie.get('foo_original') == NO_VALUE
-    cie = ConfigIniEnv([ini_filename_original])
-    # ... but it is there if only the original is loaded (safety check)
-    assert cie.get('foo_original') == 'original'
-
-
-def test_ConfigIniEnv_does_not_parse_lists(datadir):
-    ini_filename = os.path.join(datadir, 'config_test.ini')
-    cie = ConfigIniEnv([ini_filename])
-    assert cie.get('bar') == 'test1,test2'
 
 
 def test_ConfigEnvFileEnv(datadir):


### PR DESCRIPTION
This fixes Everett so that configobj is no longer a hard requirement
since it's only used by ConfigIniEnv and if you don't use that, then
you shouldn't need to install configobj.

Fixes #79