### PR TITLE
Fix nested BoundConfig case

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,22 +2,12 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.8
+      - image: themattrix/tox
 
     working_directory: ~/repo
 
     steps:
       - checkout
-
-      - run:
-          name: install tox
-          command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip install tox
-
       - run:
           name: run tests
-          command: |
-            . venv/bin/activate
-            tox
+          command: tox

--- a/everett/manager.py
+++ b/everett/manager.py
@@ -545,9 +545,6 @@ class ConfigManagerBase(object):
     def with_options(self, component):
         options = component.get_required_config()
         component_name = _get_component_name(component)
-
-        # If this is a config that's not nestable, we want to unwrap it one
-        # level because otherwise lookups won't work.
         return BoundConfig(self._get_base_config(), component_name, options)
 
     def with_namespace(self, namespace):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -100,6 +100,35 @@ def test_with_options():
         comp2.config('bar')
 
 
+def test_nested_options():
+    """Verify nested BoundOptions works."""
+    config = ConfigManager.from_dict({})
+
+    class Foo(RequiredConfigMixin):
+        required_config = ConfigOptions()
+        required_config.add_option(
+            'option1',
+            default='opt1default',
+            parser=str
+        )
+
+    class Bar(RequiredConfigMixin):
+        required_config = ConfigOptions()
+        required_config.add_option(
+            'option2',
+            default='opt2default',
+            parser=str
+        )
+
+    config = ConfigManager.basic_config()
+    config = config.with_options(Foo)
+    config = config.with_options(Bar)
+
+    assert config('option2') == 'opt2default'
+    with pytest.raises(ConfigurationError):
+        config('option1')
+
+
 def test_default_comes_from_options():
     """Verify that the default is picked up from options"""
     config = ConfigManager([])


### PR DESCRIPTION
In a situation where there are nested `BoundConfigs` in the config chain, then parents configs will raise a `KeyError` because that key isn't in *their* options.

This fixes that by removing `BoundConfigs` from the chain.

This also adds `__repr__` which will make things easier to debug in complex config scenarios.