### PR TITLE
Add Makefile; reformat code with black

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+DEFAULT_GOAL := help
+PROJECT=everett
+
+.PHONY: help
+help:
+	@echo "Available rules:"
+	@fgrep -h "##" Makefile | fgrep -v fgrep | sed 's/\(.*\):.*##/\1:/'
+
+.PHONY: clean
+clean:  ## Clean build artifacts
+	rm -rf build dist ${PROJECT}.egg-info .tox
+	rm -rf docs/_build/*
+	find ${PROJECT}/ tests/ -name __pycache__ | xargs rm -rf
+	find ${PROJECT}/ tests/ -name '*.pyc' | xargs rm -rf
+
+.PHONY: lint
+lint:  ## Lint and black reformat files
+	black --target-version=py35 ${PROJECT} tests
+	flake8 ${PROJECT} tests

--- a/everett/__init__.py
+++ b/everett/__init__.py
@@ -5,13 +5,13 @@
 
 """Everett is a Python library for configuration."""
 
-__author__ = 'Will Kahn-Greene'
-__email__ = 'willkg@mozilla.com'
+__author__ = "Will Kahn-Greene"
+__email__ = "willkg@mozilla.com"
 
 # yyyymmdd
-__releasedate__ = ''
+__releasedate__ = ""
 # x.y.z or x.y.z.dev0
-__version__ = '1.0.3.dev0'
+__version__ = "1.0.3.dev0"
 
 
 # _NoValue instances are always false
@@ -23,7 +23,7 @@ class _NoValue(object):
         return False
 
     def __repr__(self):
-        return 'NO_VALUE'
+        return "NO_VALUE"
 
 
 # Singleton indicating a non-value

--- a/everett/component.py
+++ b/everett/component.py
@@ -13,8 +13,15 @@ from everett.manager import BoundConfig
 class Option(object):
     """A single option comprised of a key and settings."""
 
-    def __init__(self, key, default=NO_VALUE, alternate_keys=NO_VALUE, doc='',
-                 parser=str, meta=None):
+    def __init__(
+        self,
+        key,
+        default=NO_VALUE,
+        alternate_keys=NO_VALUE,
+        doc="",
+        parser=str,
+        meta=None,
+    ):
         self.key = key
         self.default = default
         self.alternate_keys = alternate_keys
@@ -24,13 +31,13 @@ class Option(object):
 
     def __eq__(self, obj):
         return (
-            isinstance(obj, Option) and
-            obj.key == self.key and
-            obj.default == self.default and
-            obj.alternate_keys == self.alternate_keys and
-            obj.doc == self.doc and
-            obj.parser == self.parser and
-            obj.meta == self.meta
+            isinstance(obj, Option)
+            and obj.key == self.key
+            and obj.default == self.default
+            and obj.alternate_keys == self.alternate_keys
+            and obj.doc == self.doc
+            and obj.parser == self.parser
+            and obj.meta == self.meta
         )
 
 
@@ -40,8 +47,9 @@ class ConfigOptions(object):
     def __init__(self):
         self.options = OrderedDict()
 
-    def add_option(self, key, default=NO_VALUE, alternate_keys=NO_VALUE,
-                   doc='', parser=str, **meta):
+    def add_option(
+        self, key, default=NO_VALUE, alternate_keys=NO_VALUE, doc="", parser=str, **meta
+    ):
         """Add an option to the group.
 
         :arg key: the key to look up
@@ -67,7 +75,7 @@ class ConfigOptions(object):
             alternate_keys=alternate_keys,
             doc=doc,
             parser=parser,
-            meta=meta
+            meta=meta,
         )
         self.options[key] = option
 
@@ -163,9 +171,14 @@ class RequiredConfigMixin(object):
         """
         namespace = namespace or []
 
-        cfg = getattr(self, 'config', None)
+        cfg = getattr(self, "config", None)
         if cfg is None or not isinstance(cfg, BoundConfig):
             return
 
         for opt in self.get_required_config():
-            yield (namespace, opt.key, self.config(opt.key, raise_error=False, raw_value=True), opt)
+            yield (
+                namespace,
+                opt.key,
+                self.config(opt.key, raise_error=False, raw_value=True),
+                opt,
+            )

--- a/everett/ext/inifile.py
+++ b/everett/ext/inifile.py
@@ -19,7 +19,7 @@ from everett import NO_VALUE
 from everett.manager import generate_uppercase_key, get_key_from_envs, listify
 
 
-logger = logging.getLogger('everett')
+logger = logging.getLogger("everett")
 
 
 class ConfigIniEnv(object):
@@ -137,7 +137,7 @@ class ConfigIniEnv(object):
                 break
 
         if not self.path:
-            logger.debug('No INI file found: %s', possible_paths)
+            logger.debug("No INI file found: %s", possible_paths)
 
     def parse_ini_file(self, path):
         """Parse ini file at ``path`` and return dict."""
@@ -149,7 +149,7 @@ class ConfigIniEnv(object):
                 if isinstance(d[key], dict):
                     cfg.update(extract_section(namespace + [key], d[key]))
                 else:
-                    cfg['_'.join(namespace + [key]).upper()] = val
+                    cfg["_".join(namespace + [key]).upper()] = val
 
             return cfg
 
@@ -161,10 +161,10 @@ class ConfigIniEnv(object):
             return NO_VALUE
 
         # NOTE(willkg): The "main" section is considered the root mainspace.
-        namespace = namespace or ['main']
-        logger.debug('Searching %r for key: %s, namespace: %s', self, key, namespace)
+        namespace = namespace or ["main"]
+        logger.debug("Searching %r for key: %s, namespace: %s", self, key, namespace)
         full_key = generate_uppercase_key(key, namespace)
         return get_key_from_envs(self.cfg, full_key)
 
     def __repr__(self):
-        return '<ConfigIniEnv: %s>' % self.path
+        return "<ConfigIniEnv: %s>" % self.path

--- a/everett/ext/yamlfile.py
+++ b/everett/ext/yamlfile.py
@@ -19,7 +19,7 @@ from everett import ConfigurationError, NO_VALUE
 from everett.manager import generate_uppercase_key, get_key_from_envs, listify
 
 
-logger = logging.getLogger('everett')
+logger = logging.getLogger("everett")
 
 
 class ConfigYamlEnv(object):
@@ -124,11 +124,11 @@ class ConfigYamlEnv(object):
                 break
 
         if not self.path:
-            logger.debug('No YAML file found: %s', possible_paths)
+            logger.debug("No YAML file found: %s", possible_paths)
 
     def parse_yaml_file(self, path):
         """Parse yaml file at ``path`` and return a dict."""
-        with open(path, 'r') as fp:
+        with open(path, "r") as fp:
             data = yaml.safe_load(fp)
 
         if not data:
@@ -140,15 +140,14 @@ class ConfigYamlEnv(object):
                 if isinstance(val, dict):
                     cfg.update(traverse(namespace + [key], val))
                 elif isinstance(val, str):
-                    cfg['_'.join(namespace + [key]).upper()] = val
+                    cfg["_".join(namespace + [key]).upper()] = val
                 else:
                     # All values should be double-quoted strings so they
                     # parse as strings; anything else is a configuration
                     # error at parse-time
                     raise ConfigurationError(
-                        'Invalid value %r in file %s: values must be double-quoted strings' % (
-                            val, path
-                        )
+                        "Invalid value %r in file %s: values must be double-quoted strings"
+                        % (val, path)
                     )
 
             return cfg
@@ -160,9 +159,9 @@ class ConfigYamlEnv(object):
         if not self.path:
             return NO_VALUE
 
-        logger.debug('Searching %r for key: %s, namepsace: %s', self, key, namespace)
+        logger.debug("Searching %r for key: %s, namepsace: %s", self, key, namespace)
         full_key = generate_uppercase_key(key, namespace)
         return get_key_from_envs(self.cfg, full_key)
 
     def __repr__(self):
-        return '<ConfigYamlEnv: %s>' % self.path
+        return "<ConfigYamlEnv: %s>" % self.path

--- a/everett/manager.py
+++ b/everett/manager.py
@@ -31,9 +31,9 @@ from everett import (
 _CONFIG_OVERRIDE = []
 
 # Regex for valid keys in an env file
-ENV_KEY_RE = re.compile(r'^[a-z][a-z0-9_]*$', flags=re.IGNORECASE)
+ENV_KEY_RE = re.compile(r"^[a-z][a-z0-9_]*$", flags=re.IGNORECASE)
 
-logger = logging.getLogger('everett')
+logger = logging.getLogger("everett")
 
 
 def qualname(thing):
@@ -52,22 +52,22 @@ def qualname(thing):
 
     # Add the module, unless it's a builtin
     mod = inspect.getmodule(thing)
-    if mod and mod.__name__ not in ('__main__', '__builtin__', 'builtins'):
+    if mod and mod.__name__ not in ("__main__", "__builtin__", "builtins"):
         parts.append(mod.__name__)
 
     # If there's a __qualname__, use that
-    if hasattr(thing, '__qualname__'):
+    if hasattr(thing, "__qualname__"):
         parts.append(thing.__qualname__)
-        return '.'.join(parts)
+        return ".".join(parts)
 
     # If it's a module
     if inspect.ismodule(thing):
-        return '.'.join(parts)
+        return ".".join(parts)
 
     # If it's a class
     if inspect.isclass(thing):
         parts.append(thing.__name__)
-        return '.'.join(parts)
+        return ".".join(parts)
 
     # If it's a function
     if isinstance(thing, (types.FunctionType, types.MethodType)):
@@ -84,7 +84,7 @@ def qualname(thing):
         elif inspect.isfunction(thing):
             parts.append(thing.__name__)
 
-        return '.'.join(parts)
+        return ".".join(parts)
 
     # It's an instance, so ... let's call repr on it
     return repr(thing)
@@ -102,8 +102,8 @@ def parse_bool(val):
     False
 
     """
-    true_vals = ('t', 'true', 'yes', 'y', '1', 'on')
-    false_vals = ('f', 'false', 'no', 'n', '0', 'off')
+    true_vals = ("t", "true", "yes", "y", "1", "on")
+    false_vals = ("f", "false", "no", "n", "0", "off")
 
     val = val.lower()
     if val in true_vals:
@@ -126,17 +126,19 @@ def parse_env_file(envfile):
     data = {}
     for line_no, line in enumerate(envfile):
         line = line.strip()
-        if not line or line.startswith('#'):
+        if not line or line.startswith("#"):
             continue
-        if '=' not in line:
-            raise ConfigurationError('Env file line missing = operator (line %s)' % (line_no + 1))
-        k, v = line.split('=', 1)
+        if "=" not in line:
+            raise ConfigurationError(
+                "Env file line missing = operator (line %s)" % (line_no + 1)
+            )
+        k, v = line.split("=", 1)
         k = k.strip()
         if not ENV_KEY_RE.match(k):
             raise ConfigurationError(
                 'Invalid variable name "%s" in env file (line %s)' % (k, (line_no + 1))
             )
-        v = v.strip().strip('\'"')
+        v = v.strip().strip("'\"")
         data[k] = v
 
     return data
@@ -149,13 +151,13 @@ def parse_class(val):
     <built-in function openssl_md5>
 
     """
-    module, class_name = val.rsplit('.', 1)
+    module, class_name = val.rsplit(".", 1)
     module = importlib.import_module(module)
     try:
         return getattr(module, class_name)
     except AttributeError:
-        raise ValueError('"%s" is not a valid member of %s' % (
-            class_name, qualname(module))
+        raise ValueError(
+            '"%s" is not a valid member of %s' % (class_name, qualname(module))
         )
 
 
@@ -190,7 +192,7 @@ def generate_uppercase_key(key, namespace=None):
     """Given a key and a namespace, generates a final uppercase key."""
     if namespace:
         namespace = [part for part in listify(namespace) if part]
-        key = '_'.join(namespace + [key])
+        key = "_".join(namespace + [key])
 
     key = key.upper()
     return key
@@ -204,7 +206,7 @@ def get_key_from_envs(envs, key):
     """
     # if it barks like a dict, make it a list have to use `get` since dicts and
     # lists both have __getitem__
-    if hasattr(envs, 'get'):
+    if hasattr(envs, "get"):
         envs = [envs]
 
     for env in envs:
@@ -234,7 +236,7 @@ class ListOf(object):
 
     """
 
-    def __init__(self, parser, delimiter=','):
+    def __init__(self, parser, delimiter=","):
         self.sub_parser = parser
         self.delimiter = delimiter
 
@@ -246,7 +248,7 @@ class ListOf(object):
             return []
 
     def __repr__(self):
-        return '<ListOf(%s)>' % qualname(self.sub_parser)
+        return "<ListOf(%s)>" % qualname(self.sub_parser)
 
 
 class ConfigOverrideEnv(object):
@@ -258,11 +260,11 @@ class ConfigOverrideEnv(object):
         if not _CONFIG_OVERRIDE:
             return NO_VALUE
         full_key = generate_uppercase_key(key, namespace)
-        logger.debug('Searching %s for %s', self, full_key)
+        logger.debug("Searching %s for %s", self, full_key)
         return get_key_from_envs(reversed(_CONFIG_OVERRIDE), full_key)
 
     def __repr__(self):
-        return '<ConfigOverrideEnv>'
+        return "<ConfigOverrideEnv>"
 
 
 class ConfigObjEnv(object):
@@ -314,12 +316,11 @@ class ConfigObjEnv(object):
         full_key = generate_uppercase_key(key, namespace)
         full_key = full_key.lower()
 
-        logger.debug('Searching %s for %s', self, full_key)
+        logger.debug("Searching %s for %s", self, full_key)
 
         # Build a map of lowercase -> actual key
         obj_keys = {
-            item.lower(): item
-            for item in dir(self.obj) if not item.startswith('__')
+            item.lower(): item for item in dir(self.obj) if not item.startswith("__")
         }
 
         if full_key in obj_keys:
@@ -336,7 +337,7 @@ class ConfigObjEnv(object):
         return NO_VALUE
 
     def __repr__(self):
-        return '<ConfigObjEnv>'
+        return "<ConfigObjEnv>"
 
 
 class ConfigDictEnv(object):
@@ -393,18 +394,16 @@ class ConfigDictEnv(object):
     """
 
     def __init__(self, cfg):
-        self.cfg = dict(
-            (key.upper(), val) for key, val in cfg.items()
-        )
+        self.cfg = dict((key.upper(), val) for key, val in cfg.items())
 
     def get(self, key, namespace=None):
         """Retrieve value for key."""
         full_key = generate_uppercase_key(key, namespace)
-        logger.debug('Searching %s for %s', self, full_key)
+        logger.debug("Searching %s for %s", self, full_key)
         return get_key_from_envs(self.cfg, full_key)
 
     def __repr__(self):
-        return '<ConfigDictEnv: %r>' % self.cfg
+        return "<ConfigDictEnv: %r>" % self.cfg
 
 
 class ConfigEnvFileEnv(object):
@@ -476,11 +475,11 @@ class ConfigEnvFileEnv(object):
     def get(self, key, namespace=None):
         """Retrieve value for key."""
         full_key = generate_uppercase_key(key, namespace)
-        logger.debug('Searching %s for %s', self, full_key)
+        logger.debug("Searching %s for %s", self, full_key)
         return get_key_from_envs(self.data, full_key)
 
     def __repr__(self):
-        return '<ConfigEnvFileEnv: %s>' % self.path
+        return "<ConfigEnvFileEnv: %s>" % self.path
 
 
 class ConfigOSEnv(object):
@@ -529,11 +528,11 @@ class ConfigOSEnv(object):
     def get(self, key, namespace=None):
         """Retrieve value for key."""
         full_key = generate_uppercase_key(key, namespace)
-        logger.debug('Searching %s for %s', self, full_key)
+        logger.debug("Searching %s for %s", self, full_key)
         return get_key_from_envs(os.environ, full_key)
 
     def __repr__(self):
-        return '<ConfigOSEnv>'
+        return "<ConfigOSEnv>"
 
 
 def _get_component_name(component):
@@ -541,7 +540,7 @@ def _get_component_name(component):
         cls = component.__class__
     else:
         cls = component
-    return cls.__module__ + '.' + cls.__name__
+    return cls.__module__ + "." + cls.__name__
 
 
 class ConfigManagerBase(object):
@@ -569,7 +568,7 @@ class ConfigManagerBase(object):
         return NamespacedConfig(self._get_base_config(), namespace)
 
     def __repr__(self):
-        return '<ConfigManagerBase>'
+        return "<ConfigManagerBase>"
 
 
 class BoundConfig(ConfigManagerBase):
@@ -600,9 +599,17 @@ class BoundConfig(ConfigManagerBase):
         """
         return self.config.get_namespace()
 
-    def __call__(self, key, namespace=None, default=NO_VALUE,
-                 alternate_keys=NO_VALUE, doc='', parser=str, raise_error=True,
-                 raw_value=False):
+    def __call__(
+        self,
+        key,
+        namespace=None,
+        default=NO_VALUE,
+        alternate_keys=NO_VALUE,
+        doc="",
+        parser=str,
+        raise_error=True,
+        raw_value=False,
+    ):
         """Return a config value bound to a component's options.
 
         :arg key: the key to look up
@@ -630,7 +637,7 @@ class BoundConfig(ConfigManagerBase):
         except KeyError:
             if raise_error:
                 raise InvalidKeyError(
-                    '%s is not a valid key for this component' % (key,)
+                    "%s is not a valid key for this component" % (key,)
                 )
             return None
 
@@ -642,11 +649,14 @@ class BoundConfig(ConfigManagerBase):
             doc=option.doc,
             parser=option.parser,
             raise_error=raise_error,
-            raw_value=raw_value
+            raw_value=raw_value,
         )
 
     def __repr__(self):
-        return '<BoundConfig(%s): namespace:%s>' % (self.component_name, self.get_namespace())
+        return "<BoundConfig(%s): namespace:%s>" % (
+            self.component_name,
+            self.get_namespace(),
+        )
 
 
 class NamespacedConfig(ConfigManagerBase):
@@ -669,9 +679,17 @@ class NamespacedConfig(ConfigManagerBase):
         """
         return self.config.get_namespace() + [self.namespace]
 
-    def __call__(self, key, namespace=None, default=NO_VALUE,
-                 alternate_keys=NO_VALUE, doc='', parser=str, raise_error=True,
-                 raw_value=False):
+    def __call__(
+        self,
+        key,
+        namespace=None,
+        default=NO_VALUE,
+        alternate_keys=NO_VALUE,
+        doc="",
+        parser=str,
+        raise_error=True,
+        raw_value=False,
+    ):
         """Return a config value bound to a component's options.
 
         :arg key: the key to look up
@@ -712,17 +730,17 @@ class NamespacedConfig(ConfigManagerBase):
             alternate_keys=alternate_keys,
             parser=parser,
             raise_error=raise_error,
-            raw_value=raw_value
+            raw_value=raw_value,
         )
 
     def __repr__(self):
-        return '<NamespacedConfig: namespace:%s>' % self.get_namespace()
+        return "<NamespacedConfig: namespace:%s>" % self.get_namespace()
 
 
 class ConfigManager(ConfigManagerBase):
     """Manage multiple configuration environment layers."""
 
-    def __init__(self, environments, doc='', with_override=True):
+    def __init__(self, environments, doc="", with_override=True):
         """Instantiate a ConfigManager.
 
         :arg environents: list of configuration sources to look through in
@@ -744,7 +762,7 @@ class ConfigManager(ConfigManagerBase):
         self.doc = doc
 
     @classmethod
-    def basic_config(cls, env_file='.env'):
+    def basic_config(cls, env_file=".env"):
         """Return a basic ConfigManager.
 
         This sets up a ConfigManager that will look for configuration in
@@ -777,12 +795,7 @@ class ConfigManager(ConfigManagerBase):
         :returns: a :py:class:`everett.manager.ConfigManager`
 
         """
-        return cls(
-            environments=[
-                ConfigOSEnv(),
-                ConfigEnvFileEnv([env_file])
-            ]
-        )
+        return cls(environments=[ConfigOSEnv(), ConfigEnvFileEnv([env_file])])
 
     @classmethod
     def from_dict(cls, dict_config):
@@ -805,9 +818,17 @@ class ConfigManager(ConfigManagerBase):
         """
         return cls([ConfigDictEnv(dict_config)])
 
-    def __call__(self, key, namespace=None, default=NO_VALUE,
-                 alternate_keys=NO_VALUE, doc='', parser=str, raise_error=True,
-                 raw_value=False):
+    def __call__(
+        self,
+        key,
+        namespace=None,
+        default=NO_VALUE,
+        alternate_keys=NO_VALUE,
+        doc="",
+        parser=str,
+        raise_error=True,
+        raw_value=False,
+    ):
         """Return a parsed value from the environment.
 
         :arg key: the key to look up
@@ -883,9 +904,7 @@ class ConfigManager(ConfigManagerBase):
 
         """
         if not (default is NO_VALUE or isinstance(default, str)):
-            raise ConfigurationError(
-                'default value %r is not a string' % (default,)
-            )
+            raise ConfigurationError("default value %r is not a string" % (default,))
 
         if raw_value:
             # If we're returning raw values, then we can just use str which is
@@ -895,9 +914,7 @@ class ConfigManager(ConfigManagerBase):
             parser = get_parser(parser)
 
         def build_msg(*pargs):
-            return '\n'.join([
-                item for item in pargs if item
-            ])
+            return "\n".join([item for item in pargs if item])
 
         # Go through all possible keys
         all_keys = [key]
@@ -905,14 +922,16 @@ class ConfigManager(ConfigManagerBase):
             all_keys = all_keys + alternate_keys
 
         for possible_key in all_keys:
-            if possible_key.startswith('root:'):
+            if possible_key.startswith("root:"):
                 # If this is a root-anchored key, we drop the namespace.
                 possible_key = possible_key[5:]
                 use_namespace = None
             else:
                 use_namespace = namespace
 
-            logger.debug('Looking up key: %s, namespace: %s', possible_key, use_namespace)
+            logger.debug(
+                "Looking up key: %s, namespace: %s", possible_key, use_namespace
+            )
 
             # Go through environments in reverse order
             for env in self.envs:
@@ -921,7 +940,7 @@ class ConfigManager(ConfigManagerBase):
                 if val is not NO_VALUE:
                     try:
                         parsed_val = parser(val)
-                        logger.debug('Returning raw: %r, parsed: %r', val, parsed_val)
+                        logger.debug("Returning raw: %r, parsed: %r", val, parsed_val)
                         return parsed_val
                     except ConfigurationError:
                         # Re-raise ConfigurationError and friends since that's
@@ -930,17 +949,16 @@ class ConfigManager(ConfigManagerBase):
                     except Exception:
                         exc_info = sys.exc_info()
                         msg = build_msg(
-                            '%(class)s: %(msg)s' % {
-                                'class': exc_info[0].__name__,
-                                'msg': str(exc_info[1])
-                            },
-                            'namespace=%(namespace)s key=%(key)s requires a value parseable by %(parser)s' % {  # noqa
-                                'namespace': use_namespace,
-                                'key': key,
-                                'parser': qualname(parser)
+                            "%(class)s: %(msg)s"
+                            % {"class": exc_info[0].__name__, "msg": str(exc_info[1])},
+                            "namespace=%(namespace)s key=%(key)s requires a value parseable by %(parser)s"
+                            % {  # noqa
+                                "namespace": use_namespace,
+                                "key": key,
+                                "parser": qualname(parser),
                             },
                             doc,
-                            self.doc
+                            self.doc,
                         )
 
                         raise InvalidValueError(msg, namespace, key, parser)
@@ -949,7 +967,9 @@ class ConfigManager(ConfigManagerBase):
         if default is not NO_VALUE:
             try:
                 parsed_val = parser(default)
-                logger.debug('Returning default raw: %r, parsed: %r', default, parsed_val)
+                logger.debug(
+                    "Returning default raw: %r, parsed: %r", default, parsed_val
+                )
                 return parsed_val
             except ConfigurationError:
                 # Re-raise ConfigurationError and friends since that's
@@ -960,17 +980,16 @@ class ConfigManager(ConfigManagerBase):
                 # configuration error. We might want to denote that better.
                 exc_info = sys.exc_info()
                 msg = build_msg(
-                    '%(class)s: %(msg)s' % {
-                        'class': exc_info[0].__name__,
-                        'msg': str(exc_info[1])
-                    },
-                    'namespace=%(namespace)s key=%(key)s requires a default value parseable by %(parser)s' % {  # noqa
-                        'namespace': namespace,
-                        'key': key,
-                        'parser': qualname(parser)
+                    "%(class)s: %(msg)s"
+                    % {"class": exc_info[0].__name__, "msg": str(exc_info[1])},
+                    "namespace=%(namespace)s key=%(key)s requires a default value parseable by %(parser)s"
+                    % {  # noqa
+                        "namespace": namespace,
+                        "key": key,
+                        "parser": qualname(parser),
                     },
                     doc,
-                    self.doc
+                    self.doc,
                 )
 
                 raise InvalidValueError(msg, namespace, key, parser)
@@ -978,23 +997,20 @@ class ConfigManager(ConfigManagerBase):
         # No value specified and no default, so raise an error to the user
         if raise_error:
             msg = build_msg(
-                'namespace=%(namespace)s key=%(key)s requires a value parseable by %(parser)s' % {
-                    'namespace': namespace,
-                    'key': key,
-                    'parser': qualname(parser)
-                },
+                "namespace=%(namespace)s key=%(key)s requires a value parseable by %(parser)s"
+                % {"namespace": namespace, "key": key, "parser": qualname(parser)},
                 doc,
-                self.doc
+                self.doc,
             )
 
             raise ConfigurationMissingError(msg, namespace, key, parser)
 
-        logger.debug('Found nothing--returning NO_VALUE')
+        logger.debug("Found nothing--returning NO_VALUE")
         # Otherwise return NO_VALUE
         return NO_VALUE
 
     def __repr__(self):
-        return '<ConfigManager>'
+        return "<ConfigManager>"
 
 
 class ConfigOverride(object):
@@ -1023,6 +1039,7 @@ class ConfigOverride(object):
 
     def decorate(self, fun):
         """Decorate a function for overriding configuration."""
+
         @wraps(fun)
         def _decorated(*args, **kwargs):
             # Push the config, run the function and pop it afterwards.
@@ -1031,6 +1048,7 @@ class ConfigOverride(object):
                 return fun(*args, **kwargs)
             finally:
                 self.pop_config()
+
         return _decorated
 
     def __call__(self, class_or_fun):
@@ -1039,7 +1057,7 @@ class ConfigOverride(object):
             # that start with 'test'.
             for attr in class_or_fun.__dict__.keys():
                 prop = getattr(class_or_fun, attr)
-                if attr.startswith('test') and callable(prop):
+                if attr.startswith("test") and callable(prop):
                     setattr(class_or_fun, attr, self.decorate(prop))
             return class_or_fun
 

--- a/everett/sphinxext.py
+++ b/everett/sphinxext.py
@@ -149,7 +149,7 @@ def split_clspath(clspath):
     Note: This is a really simplistic implementation.
 
     """
-    return clspath.rsplit('.', 1)
+    return clspath.rsplit(".", 1)
 
 
 def import_class(clspath):
@@ -170,7 +170,7 @@ def upper_lower_none(arg):
         return arg
 
     arg = arg.strip().lower()
-    if arg in ['upper', 'lower']:
+    if arg in ["upper", "lower"]:
         return arg
 
     raise ValueError('argument must be "upper", "lower" or None')
@@ -180,30 +180,34 @@ class EverettComponent(ObjectDescription):
     """Description of an Everett component."""
 
     doc_field_types = [
-        TypedField('options', label=_('Options'),
-                   names=('option', 'opt'),
-                   typerolename='obj', typenames=('parser',),
-                   can_collapse=True),
+        TypedField(
+            "options",
+            label=_("Options"),
+            names=("option", "opt"),
+            typerolename="obj",
+            typenames=("parser",),
+            can_collapse=True,
+        )
     ]
 
     allow_nesting = False
 
     def handle_signature(self, sig, signode):
         """Create a signature for this thing."""
-        if sig != 'Configuration':
+        if sig != "Configuration":
             signode.clear()
 
             # Add "component" which is the type of this thing
-            signode += addnodes.desc_annotation('component ', 'component ')
+            signode += addnodes.desc_annotation("component ", "component ")
 
-            if '.' in sig:
-                modname, clsname = sig.rsplit('.', 1)
+            if "." in sig:
+                modname, clsname = sig.rsplit(".", 1)
             else:
-                modname, clsname = '', sig
+                modname, clsname = "", sig
 
             # If there's a module name, then we add the module
             if modname:
-                signode += addnodes.desc_addname(modname + '.', modname + '.')
+                signode += addnodes.desc_addname(modname + ".", modname + ".")
 
             # Add the class name
             signode += addnodes.desc_name(clsname, clsname)
@@ -215,61 +219,55 @@ class EverettComponent(ObjectDescription):
 
     def add_target_and_index(self, name, sig, signode):
         """Add a target and index for this thing."""
-        targetname = '%s-%s' % (self.objtype, name)
+        targetname = "%s-%s" % (self.objtype, name)
 
         if targetname not in self.state.document.ids:
-            signode['names'].append(targetname)
-            signode['ids'].append(targetname)
-            signode['first'] = (not self.names)
+            signode["names"].append(targetname)
+            signode["ids"].append(targetname)
+            signode["first"] = not self.names
             self.state.document.note_explicit_target(signode)
 
-            objects = self.env.domaindata['everett']['objects']
+            objects = self.env.domaindata["everett"]["objects"]
             key = (self.objtype, name)
             if key in objects:
                 self.state_machine.reporter.warning(
-                    'duplicate description of %s %s, ' % (self.objtype, name) +
-                    'other instance in ' + self.env.doc2path(objects[key]),
-                    line=self.lineno
+                    "duplicate description of %s %s, " % (self.objtype, name)
+                    + "other instance in "
+                    + self.env.doc2path(objects[key]),
+                    line=self.lineno,
                 )
             objects[key] = self.env.docname
 
-        indextext = _('%s (component)') % name
-        self.indexnode['entries'].append(('single', indextext, targetname, '', None))
+        indextext = _("%s (component)") % name
+        self.indexnode["entries"].append(("single", indextext, targetname, "", None))
 
 
 class EverettDomain(Domain):
     """Everett domain for component configuration."""
 
-    name = 'everett'
-    label = 'Everett'
+    name = "everett"
+    label = "Everett"
 
-    object_types = {
-        'component': ObjType(_('component'), 'comp'),
-    }
-    directives = {
-        'component': EverettComponent,
-    }
-    roles = {
-        'component': XRefRole(),
-        'comp': XRefRole(),
-    }
+    object_types = {"component": ObjType(_("component"), "comp")}
+    directives = {"component": EverettComponent}
+    roles = {"component": XRefRole(), "comp": XRefRole()}
     initial_data = {
         # (typ, clspath) -> sphinx document name
-        'objects': {},
+        "objects": {}
     }
 
     def clear_doc(self, docname):
-        for (typ, name), doc in list(self.data['objects'].items()):
+        for (typ, name), doc in list(self.data["objects"].items()):
             if doc == docname:
-                del self.data['objects'][typ, name]
+                del self.data["objects"][typ, name]
 
     def merge_domaindata(self, docnames, otherdata):
-        for (typ, name), doc in otherdata['objects'].items():
+        for (typ, name), doc in otherdata["objects"].items():
             if doc in docnames:
-                self.data['objects'][typ, name] = doc
+                self.data["objects"][typ, name] = doc
 
     def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
-        objects = self.data['objects']
+        objects = self.data["objects"]
         objtypes = self.objtypes_for_role(typ) or []
 
         for objtype in objtypes:
@@ -280,23 +278,23 @@ class EverettDomain(Domain):
                         builder,
                         fromdocname,
                         objects[typ, clspath],
-                        objtype + '-' + target,
+                        objtype + "-" + target,
                         contnode,
-                        target + ' ' + objtype
+                        target + " " + objtype,
                     )
 
                 # Try looking it up by the class name--this lets people use
                 # shorthand in their roles
-                if '.' in clspath:
+                if "." in clspath:
                     modname, clsname = split_clspath(clspath)
                     if (objtype, target) == (typ, clsname):
                         return make_refnode(
                             builder,
                             fromdocname,
                             objects[typ, clspath],
-                            objtype + '-' + clspath,
+                            objtype + "-" + clspath,
                             contnode,
-                            target + ' ' + objtype
+                            target + " " + objtype,
                         )
 
 
@@ -310,16 +308,13 @@ class AutoComponentDirective(Directive):
         # Whether or not to show the class docstring--if None, don't show the
         # docstring, if empty string use __doc__, otherwise use the value of
         # the attribute on the class
-        'show-docstring': directives.unchanged,
-
+        "show-docstring": directives.unchanged,
         # Whether or not to hide the class name
-        'hide-classname': directives.flag,
-
+        "hide-classname": directives.flag,
         # Prepend a specified namespace
-        'namespace': directives.unchanged,
-
+        "namespace": directives.unchanged,
         # Render keys in specified case
-        'case': upper_lower_none,
+        "case": upper_lower_none,
     }
 
     def add_line(self, line, source, *lineno):
@@ -329,87 +324,91 @@ class AutoComponentDirective(Directive):
     def generate_docs(self, clspath, more_content):
         """Generate documentation for this configman class"""
         obj = import_class(clspath)
-        sourcename = 'docstring of %s' % clspath
+        sourcename = "docstring of %s" % clspath
         all_options = []
-        indent = '    '
+        indent = "    "
         config = obj.get_required_config()
 
         if config.options:
             # Go through options and figure out relevant information
             for option in config:
-                if 'namespace' in self.options:
-                    namespaced_key = self.options['namespace'] + '_' + option.key
+                if "namespace" in self.options:
+                    namespaced_key = self.options["namespace"] + "_" + option.key
                 else:
                     namespaced_key = option.key
 
-                if 'case' in self.options:
-                    if self.options['case'] == 'upper':
+                if "case" in self.options:
+                    if self.options["case"] == "upper":
                         namespaced_key = namespaced_key.upper()
-                    elif self.options['case'] == 'lower':
+                    elif self.options["case"] == "lower":
                         namespaced_key = namespaced_key.lower()
 
-                all_options.append({
-                    'key': namespaced_key,
-                    'parser': qualname(option.parser),
-                    'doc': option.doc,
-                    'default': option.default,
-                })
+                all_options.append(
+                    {
+                        "key": namespaced_key,
+                        "parser": qualname(option.parser),
+                        "doc": option.doc,
+                        "default": option.default,
+                    }
+                )
 
-        if 'hide-classname' not in self.options:
+        if "hide-classname" not in self.options:
             modname, clsname = split_clspath(clspath)
             component_name = clspath
             component_index = clsname
         else:
-            component_name = 'Configuration'
-            component_index = 'Configuration'
+            component_name = "Configuration"
+            component_index = "Configuration"
 
         if all_options:
             # Add index entries for options first so they link to the right
             # place; we do it this way so that we don't have to make options a
             # real object type and then we don't get to use TypedField
             # formatting
-            self.add_line('.. index::', sourcename)
+            self.add_line(".. index::", sourcename)
             for option in all_options:
-                self.add_line('   single: %s; (%s)' % (option['key'], component_index), sourcename)
-            self.add_line('', '')
+                self.add_line(
+                    "   single: %s; (%s)" % (option["key"], component_index), sourcename
+                )
+            self.add_line("", "")
 
         # Add the classname or 'Configuration'
-        self.add_line('.. everett:component:: %s' % component_name, sourcename)
-        self.add_line('', sourcename)
+        self.add_line(".. everett:component:: %s" % component_name, sourcename)
+        self.add_line("", sourcename)
 
         # Add the docstring if there is one and if show-docstring
-        if 'show-docstring' in self.options:
-            docstring_attr = self.options['show-docstring'] or '__doc__'
+        if "show-docstring" in self.options:
+            docstring_attr = self.options["show-docstring"] or "__doc__"
             docstring = getattr(obj, docstring_attr, None)
             if docstring:
                 docstringlines = prepare_docstring(docstring, ignore=1)
                 for i, line in enumerate(docstringlines):
                     self.add_line(indent + line, sourcename, i)
-                self.add_line('', '')
+                self.add_line("", "")
 
         # Add content from the directive if there was any
         if more_content:
             for line, src in zip(more_content.data, more_content.items):
                 self.add_line(indent + line, src[0], src[1])
-            self.add_line('', '')
+            self.add_line("", "")
 
         if all_options:
             # Now list the options
-            sourcename = 'class definition'
+            sourcename = "class definition"
 
             for option in all_options:
                 self.add_line(
-                    '%s:option %s %s:' % (indent, option['parser'], option['key']),
-                    sourcename
+                    "%s:option %s %s:" % (indent, option["parser"], option["key"]),
+                    sourcename,
                 )
-                self.add_line('%s    %s' % (indent, option['doc']), sourcename)
-                if option['default'] is not NO_VALUE:
-                    self.add_line('', '')
+                self.add_line("%s    %s" % (indent, option["doc"]), sourcename)
+                if option["default"] is not NO_VALUE:
+                    self.add_line("", "")
                     self.add_line(
-                        '%s    Defaults to ``%r``.' % (indent, option['default']),
-                        sourcename
+                        "%s    Defaults to ``%r``." % (indent, option["default"]),
+                        sourcename,
                     )
-                self.add_line('', '')
+                self.add_line("", "")
 
     def run(self):
         self.reporter = self.state.document.reporter
@@ -429,10 +428,10 @@ class AutoComponentDirective(Directive):
 def setup(app):
     """Register domain and directive in Sphinx."""
     app.add_domain(EverettDomain)
-    app.add_directive('autocomponent', AutoComponentDirective)
+    app.add_directive("autocomponent", AutoComponentDirective)
 
     return {
-        'version': __version__,
-        'parallel_read_safe': True,
-        'parallel_write_safe': True
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
     }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -e .[ini,yaml]
 
+black==19.3b0 ; python_version >= '3.6'
 check-manifest==0.40
 flake8==3.7.8
 pytest==5.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,17 +3,19 @@ universal=1
 
 [flake8]
 ignore =
-    # W504: line break after binary operator
-    W504,
-    # D100: Missing docstring in public module (pydocstyle)
-    D100,
-    # D104: Missing docstring in public package (pydocstyle)
-    D104,
-    # D105: Missing docstring in magic method
-    D105,
-    # D107: Missing docstring in __init__ (pydocstyle)
-    D107
-max-line-length = 100
+    # E203: Whitespace before ':'; doesn't work with black
+    E203,
+    # E501: line too long
+    E501,
+    # W503: line break before operator; this doesn't work with black
+    W503
+exclude =
+    .git/,
+    __pycache__,
+    docs/,
+    build/,
+    dist/
+max-line-length = 88
 
 [tool:pytest]
 filterwarnings =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,4 +8,4 @@ import pytest
 
 @pytest.fixture
 def datadir():
-    return os.path.join(os.path.dirname(__file__), 'data')
+    return os.path.join(os.path.dirname(__file__), "data")

--- a/tests/ext/test_inifile.py
+++ b/tests/ext/test_inifile.py
@@ -10,28 +10,28 @@ from everett.ext.inifile import ConfigIniEnv
 
 class TestConfigIniEnv:
     def test_basic_usage(self, datadir):
-        ini_filename = os.path.join(datadir, 'config_test.ini')
+        ini_filename = os.path.join(datadir, "config_test.ini")
         cie = ConfigIniEnv([ini_filename])
-        assert cie.get('foo') == 'bar'
-        assert cie.get('FOO') == 'bar'
-        assert cie.get('foo', namespace='nsbaz') == 'bat'
-        assert cie.get('foo', namespace=['nsbaz']) == 'bat'
-        assert cie.get('foo', namespace=['nsbaz', 'nsbaz2']) == 'bat2'
+        assert cie.get("foo") == "bar"
+        assert cie.get("FOO") == "bar"
+        assert cie.get("foo", namespace="nsbaz") == "bat"
+        assert cie.get("foo", namespace=["nsbaz"]) == "bat"
+        assert cie.get("foo", namespace=["nsbaz", "nsbaz2"]) == "bat2"
 
-        cie = ConfigIniEnv(['/a/b/c/bogus/filename'])
-        assert cie.get('foo') == NO_VALUE
+        cie = ConfigIniEnv(["/a/b/c/bogus/filename"])
+        assert cie.get("foo") == NO_VALUE
 
     def test_multiple_files(self, datadir):
-        ini_filename = os.path.join(datadir, 'config_test.ini')
-        ini_filename_original = os.path.join(datadir, 'config_test_original.ini')
+        ini_filename = os.path.join(datadir, "config_test.ini")
+        ini_filename_original = os.path.join(datadir, "config_test_original.ini")
         cie = ConfigIniEnv([ini_filename, ini_filename_original])
         # Only the first found file is loaded, so foo_original does not exist
-        assert cie.get('foo_original') == NO_VALUE
+        assert cie.get("foo_original") == NO_VALUE
         cie = ConfigIniEnv([ini_filename_original])
         # ... but it is there if only the original is loaded (safety check)
-        assert cie.get('foo_original') == 'original'
+        assert cie.get("foo_original") == "original"
 
     def test_does_not_parse_lists(self, datadir):
-        ini_filename = os.path.join(datadir, 'config_test.ini')
+        ini_filename = os.path.join(datadir, "config_test.ini")
         cie = ConfigIniEnv([ini_filename])
-        assert cie.get('bar') == 'test1,test2'
+        assert cie.get("bar") == "test1,test2"

--- a/tests/ext/test_yamlfile.py
+++ b/tests/ext/test_yamlfile.py
@@ -40,62 +40,62 @@ nsbaz:
 
 class TestConfigYamlEnv:
     def test_missing_file(self):
-        cie = ConfigYamlEnv(['/a/b/c/bogus/filename'])
-        assert cie.get('foo') == NO_VALUE
+        cie = ConfigYamlEnv(["/a/b/c/bogus/filename"])
+        assert cie.get("foo") == NO_VALUE
 
     def test_flat(self, tmpdir):
         """Test flat specification works"""
-        yaml_filename = tmpdir / 'config.yaml'
+        yaml_filename = tmpdir / "config.yaml"
         yaml_filename.write(YAML_FLAT)
 
         cie = ConfigYamlEnv([str(yaml_filename)])
-        assert cie.get('foo') == 'bar'
-        assert cie.get('foo', namespace='nsbaz') == 'bat'
-        assert cie.get('foo', namespace=['nsbaz']) == 'bat'
-        assert cie.get('foo', namespace=['nsbaz', 'nsbaz2']) == 'bat2'
+        assert cie.get("foo") == "bar"
+        assert cie.get("foo", namespace="nsbaz") == "bat"
+        assert cie.get("foo", namespace=["nsbaz"]) == "bat"
+        assert cie.get("foo", namespace=["nsbaz", "nsbaz2"]) == "bat2"
 
     def test_flat_caps(self, tmpdir):
         """Test case-insensitive"""
-        yaml_filename = tmpdir / 'config.yaml'
+        yaml_filename = tmpdir / "config.yaml"
         yaml_filename.write(YAML_FLAT)
 
         cie = ConfigYamlEnv([str(yaml_filename)])
-        assert cie.get('foo') == 'bar'
-        assert cie.get('FOO') == 'bar'
-        assert cie.get('Foo') == 'bar'
-        assert cie.get('foo', namespace='nsbaz') == 'bat'
-        assert cie.get('foo', namespace='NsBaz') == 'bat'
-        assert cie.get('FOO', namespace='NSBAZ') == 'bat'
+        assert cie.get("foo") == "bar"
+        assert cie.get("FOO") == "bar"
+        assert cie.get("Foo") == "bar"
+        assert cie.get("foo", namespace="nsbaz") == "bat"
+        assert cie.get("foo", namespace="NsBaz") == "bat"
+        assert cie.get("FOO", namespace="NSBAZ") == "bat"
 
     def test_hierarchical(self, tmpdir):
         """Test hierarchical specification works"""
-        yaml_filename = tmpdir / 'config.yaml'
+        yaml_filename = tmpdir / "config.yaml"
         yaml_filename.write(YAML_HIERARCHY)
 
         cie = ConfigYamlEnv([str(yaml_filename)])
-        assert cie.get('foo') == 'bar'
-        assert cie.get('foo', namespace='nsbaz') == 'bat'
-        assert cie.get('foo', namespace=['nsbaz']) == 'bat'
-        assert cie.get('foo', namespace=['nsbaz', 'nsbaz2']) == 'bat2'
+        assert cie.get("foo") == "bar"
+        assert cie.get("foo", namespace="nsbaz") == "bat"
+        assert cie.get("foo", namespace=["nsbaz"]) == "bat"
+        assert cie.get("foo", namespace=["nsbaz", "nsbaz2"]) == "bat2"
 
     def test_multiple_files(self, tmpdir):
         """Test multiple files--uses first found"""
-        yaml_filename = tmpdir / 'config.yaml'
+        yaml_filename = tmpdir / "config.yaml"
         yaml_filename.write(YAML_FLAT)
 
-        yaml_filename_2 = tmpdir / 'config2.yaml'
+        yaml_filename_2 = tmpdir / "config2.yaml"
         yaml_filename_2.write(YAML_FLAT_2)
 
         cie = ConfigYamlEnv([str(yaml_filename), str(yaml_filename_2)])
         # Only the first found file is loaded, so foo_original does not exist
-        assert cie.get('foo_original') == NO_VALUE
+        assert cie.get("foo_original") == NO_VALUE
 
         cie = ConfigYamlEnv([str(yaml_filename_2)])
         # ... but it is there if only the original is loaded (safety check)
-        assert cie.get('foo_original') == 'original'
+        assert cie.get("foo_original") == "original"
 
     def test_non_string_values(self, tmpdir):
-        yaml_filename = tmpdir / 'config.yaml'
+        yaml_filename = tmpdir / "config.yaml"
         yaml_filename.write(YAML_NON_STRING_VALUES)
 
         with pytest.raises(ConfigurationError):

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -34,125 +34,101 @@ from everett.manager import (
 def test_no_value():
     assert bool(NO_VALUE) is False
     assert NO_VALUE is not True
-    assert str(NO_VALUE) == 'NO_VALUE'
+    assert str(NO_VALUE) == "NO_VALUE"
 
 
 def test_parse_bool_error():
     with pytest.raises(ValueError):
-        parse_bool('')
+        parse_bool("")
 
 
-@pytest.mark.parametrize('data,expected', [
-    (None, []),
-    ('', ['']),
-    ([], []),
-    ('foo', ['foo']),
-    (['foo'], ['foo']),
-    (['foo', 'bar'], ['foo', 'bar'])
-])
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        (None, []),
+        ("", [""]),
+        ([], []),
+        ("foo", ["foo"]),
+        (["foo"], ["foo"]),
+        (["foo", "bar"], ["foo", "bar"]),
+    ],
+)
 def test_listify(data, expected):
     assert listify(data) == expected
 
 
-@pytest.mark.parametrize('data', [
-    't',
-    'true',
-    'True',
-    'TRUE',
-    'y',
-    'yes',
-    'YES',
-    '1',
-    'on',
-    'On',
-    'ON',
-])
+@pytest.mark.parametrize(
+    "data", ["t", "true", "True", "TRUE", "y", "yes", "YES", "1", "on", "On", "ON"]
+)
 def test_parse_bool_true(data):
     assert parse_bool(data) is True
 
 
-@pytest.mark.parametrize('data', [
-    'f',
-    'false',
-    'False',
-    'FALSE',
-    'n',
-    'no',
-    'No',
-    'NO',
-    '0',
-    'off',
-    'Off',
-    'OFF',
-])
+@pytest.mark.parametrize(
+    "data",
+    ["f", "false", "False", "FALSE", "n", "no", "No", "NO", "0", "off", "Off", "OFF"],
+)
 def test_parse_bool_false(data):
     assert parse_bool(data) is False
 
 
 def test_parse_bool_with_config():
-    config = ConfigManager.from_dict({
-        'foo': 'bar'
-    })
+    config = ConfigManager.from_dict({"foo": "bar"})
 
     # Test key is there, but value is bad
     with pytest.raises(InvalidValueError) as excinfo:
-        config('foo', parser=bool)
+        config("foo", parser=bool)
     assert (
-        str(excinfo.value) ==
-        'ValueError: "bar" is not a valid bool value\n'
-        'namespace=None key=foo requires a value parseable by everett.manager.parse_bool'
+        str(excinfo.value) == 'ValueError: "bar" is not a valid bool value\n'
+        "namespace=None key=foo requires a value parseable by everett.manager.parse_bool"
     )
 
     # Test key is not there and default is bad
     with pytest.raises(InvalidValueError) as excinfo:
-        config('phil', default='foo', parser=bool)
+        config("phil", default="foo", parser=bool)
     assert (
-        str(excinfo.value) ==
-        'ValueError: "foo" is not a valid bool value\n'
-        'namespace=None key=phil requires a default value parseable by everett.manager.parse_bool'
+        str(excinfo.value) == 'ValueError: "foo" is not a valid bool value\n'
+        "namespace=None key=phil requires a default value parseable by everett.manager.parse_bool"
     )
 
 
 def test_parse_missing_class():
     with pytest.raises(ImportError):
-        parse_class('doesnotexist.class')
+        parse_class("doesnotexist.class")
 
     with pytest.raises(ValueError):
-        parse_class('hashlib.doesnotexist')
+        parse_class("hashlib.doesnotexist")
 
 
 def test_parse_class():
     from hashlib import md5
-    assert parse_class('hashlib.md5') == md5
+
+    assert parse_class("hashlib.md5") == md5
 
 
 def test_parse_class_config():
-    config = ConfigManager.from_dict({
-        'foo_cls': 'hashlib.doesnotexist',
-        'bar_cls': 'doesnotexist.class',
-    })
-
-    with pytest.raises(InvalidValueError) as exc_info:
-        config('foo_cls', parser=parse_class)
-    assert (
-        str(exc_info.value) ==
-        'ValueError: "doesnotexist" is not a valid member of hashlib\n'
-        'namespace=None key=foo_cls requires a value parseable by everett.manager.parse_class'
+    config = ConfigManager.from_dict(
+        {"foo_cls": "hashlib.doesnotexist", "bar_cls": "doesnotexist.class"}
     )
 
     with pytest.raises(InvalidValueError) as exc_info:
-        config('bar_cls', parser=parse_class)
+        config("foo_cls", parser=parse_class)
     assert (
-        str(exc_info.value) in
-        [
-            # Python 3
-            'ImportError: No module named \'doesnotexist\'\n'
-            'namespace=None key=bar_cls requires a value parseable by everett.manager.parse_class',
-            # Python 3.6
-            'ModuleNotFoundError: No module named \'doesnotexist\'\n'
-            'namespace=None key=bar_cls requires a value parseable by everett.manager.parse_class'
-        ]
+        str(exc_info.value)
+        == 'ValueError: "doesnotexist" is not a valid member of hashlib\n'
+        "namespace=None key=foo_cls requires a value parseable by everett.manager.parse_class"
     )
+
+    with pytest.raises(InvalidValueError) as exc_info:
+        config("bar_cls", parser=parse_class)
+    assert str(exc_info.value) in [
+        # Python 3
+        "ImportError: No module named 'doesnotexist'\n"
+        "namespace=None key=bar_cls requires a value parseable by everett.manager.parse_class",
+        # Python 3.6
+        "ModuleNotFoundError: No module named 'doesnotexist'\n"
+        "namespace=None key=bar_cls requires a value parseable by everett.manager.parse_class",
+    ]
 
 
 def test_get_parser():
@@ -164,28 +140,26 @@ def test_get_parser():
     # work.
     def foo():
         pass
+
     assert get_parser(foo) == foo
 
 
 def test_ListOf():
-    assert ListOf(str)('') == []
-    assert ListOf(str)('foo') == ['foo']
-    assert ListOf(bool)('t,f') == [True, False]
-    assert ListOf(int)('1,2,3') == [1, 2, 3]
-    assert ListOf(int, delimiter=':')('1:2') == [1, 2]
+    assert ListOf(str)("") == []
+    assert ListOf(str)("foo") == ["foo"]
+    assert ListOf(bool)("t,f") == [True, False]
+    assert ListOf(int)("1,2,3") == [1, 2, 3]
+    assert ListOf(int, delimiter=":")("1:2") == [1, 2]
 
 
 def test_ListOf_error():
-    config = ConfigManager.from_dict({
-        'bools': 't,f,badbool'
-    })
+    config = ConfigManager.from_dict({"bools": "t,f,badbool"})
     with pytest.raises(InvalidValueError) as exc_info:
-        config('bools', parser=ListOf(bool))
+        config("bools", parser=ListOf(bool))
 
     assert (
-        str(exc_info.value) ==
-        'ValueError: "badbool" is not a valid bool value\n'
-        'namespace=None key=bools requires a value parseable by <ListOf(bool)>'
+        str(exc_info.value) == 'ValueError: "badbool" is not a valid bool value\n'
+        "namespace=None key=bools requires a value parseable by <ListOf(bool)>"
     )
 
 
@@ -195,213 +169,186 @@ class TestConfigObjEnv:
             pass
 
         obj = Namespace()
-        setattr(obj, 'foo', 'bar')
-        setattr(obj, 'foo_baz', 'bar')
+        setattr(obj, "foo", "bar")
+        setattr(obj, "foo_baz", "bar")
 
         coe = ConfigObjEnv(obj)
-        assert coe.get('foo') == 'bar'
-        assert coe.get('FOO') == 'bar'
-        assert coe.get('FOO_BAZ') == 'bar'
+        assert coe.get("foo") == "bar"
+        assert coe.get("FOO") == "bar"
+        assert coe.get("FOO_BAZ") == "bar"
 
     def test_with_argparse(self):
         parser = argparse.ArgumentParser()
-        parser.add_argument(
-            '--debug', help='to debug or not to debug'
-        )
+        parser.add_argument("--debug", help="to debug or not to debug")
         parsed_vals = parser.parse_known_args([])[0]
 
-        config = ConfigManager([
-            ConfigObjEnv(parsed_vals)
-        ])
+        config = ConfigManager([ConfigObjEnv(parsed_vals)])
 
-        assert config('debug', parser=bool, raise_error=False) is NO_VALUE
+        assert config("debug", parser=bool, raise_error=False) is NO_VALUE
 
-        parsed_vals = parser.parse_known_args(['--debug=y'])[0]
+        parsed_vals = parser.parse_known_args(["--debug=y"])[0]
 
-        config = ConfigManager([
-            ConfigObjEnv(parsed_vals)
-        ])
+        config = ConfigManager([ConfigObjEnv(parsed_vals)])
 
-        assert config('debug', parser=bool) is True
+        assert config("debug", parser=bool) is True
 
     def test_with_argparse_actions(self):
         parser = argparse.ArgumentParser()
         parser.add_argument(
-            '--debug', help='to debug or not to debug', action='store_true'
+            "--debug", help="to debug or not to debug", action="store_true"
         )
         parsed_vals = parser.parse_known_args([])[0]
 
-        config = ConfigManager([
-            ConfigObjEnv(parsed_vals)
-        ])
+        config = ConfigManager([ConfigObjEnv(parsed_vals)])
 
         # What happens is that argparse doesn't see an arg, so saves
         # debug=False. ConfigObjEnv converts that to "False". That gets parsed
         # as False by the Everett parse_bool function. That's kind of
         # roundabout but "works" for some/most cases.
-        assert config('debug', parser=bool) is False
+        assert config("debug", parser=bool) is False
 
-        parsed_vals = parser.parse_known_args(['--debug'])[0]
+        parsed_vals = parser.parse_known_args(["--debug"])[0]
 
-        config = ConfigManager([
-            ConfigObjEnv(parsed_vals)
-        ])
+        config = ConfigManager([ConfigObjEnv(parsed_vals)])
 
-        assert config('debug', parser=bool) is True
+        assert config("debug", parser=bool) is True
 
 
 def test_ConfigDictEnv():
-    cde = ConfigDictEnv({
-        'FOO': 'bar',
-        'A_FOO': 'a_bar',
-        'A_B_FOO': 'a_b_bar',
-        'lower_foo': 'bar'
-    })
-    assert cde.get('foo') == 'bar'
-    assert cde.get('foo', namespace=['a']) == 'a_bar'
-    assert cde.get('foo', namespace=['a', 'b']) == 'a_b_bar'
-    assert cde.get('FOO', namespace=['a']) == 'a_bar'
-    assert cde.get('foo', namespace=['A']) == 'a_bar'
-    assert cde.get('FOO', namespace=['A']) == 'a_bar'
+    cde = ConfigDictEnv(
+        {"FOO": "bar", "A_FOO": "a_bar", "A_B_FOO": "a_b_bar", "lower_foo": "bar"}
+    )
+    assert cde.get("foo") == "bar"
+    assert cde.get("foo", namespace=["a"]) == "a_bar"
+    assert cde.get("foo", namespace=["a", "b"]) == "a_b_bar"
+    assert cde.get("FOO", namespace=["a"]) == "a_bar"
+    assert cde.get("foo", namespace=["A"]) == "a_bar"
+    assert cde.get("FOO", namespace=["A"]) == "a_bar"
 
-    cde = ConfigDictEnv({
-        'foo': 'bar',
-    })
-    assert cde.get('foo') == 'bar'
-    assert cde.get('FOO') == 'bar'
+    cde = ConfigDictEnv({"foo": "bar"})
+    assert cde.get("foo") == "bar"
+    assert cde.get("FOO") == "bar"
 
 
 def test_ConfigOSEnv():
-    os.environ['EVERETT_TEST_FOO'] = 'bar'
-    os.environ['EVERETT_TEST_FOO'] = 'bar'
+    os.environ["EVERETT_TEST_FOO"] = "bar"
+    os.environ["EVERETT_TEST_FOO"] = "bar"
     cose = ConfigOSEnv()
 
-    assert cose.get('everett_test_foo') == 'bar'
-    assert cose.get('EVERETT_test_foo') == 'bar'
-    assert cose.get('foo', namespace=['everett', 'test']) == 'bar'
+    assert cose.get("everett_test_foo") == "bar"
+    assert cose.get("EVERETT_test_foo") == "bar"
+    assert cose.get("foo", namespace=["everett", "test"]) == "bar"
 
 
 def test_ConfigEnvFileEnv(datadir):
-    env_filename = os.path.join(datadir, '.env')
-    cefe = ConfigEnvFileEnv(['/does/not/exist/.env', env_filename])
-    assert cefe.get('not_a', namespace='youre') == 'golfer'
-    assert cefe.get('loglevel') == 'walter'
-    assert cefe.get('LOGLEVEL') == 'walter'
-    assert cefe.get('missing') is NO_VALUE
+    env_filename = os.path.join(datadir, ".env")
+    cefe = ConfigEnvFileEnv(["/does/not/exist/.env", env_filename])
+    assert cefe.get("not_a", namespace="youre") == "golfer"
+    assert cefe.get("loglevel") == "walter"
+    assert cefe.get("LOGLEVEL") == "walter"
+    assert cefe.get("missing") is NO_VALUE
     assert cefe.data == {
-        'LOGLEVEL': 'walter',
-        'DEBUG': 'True',
-        'YOURE_NOT_A': 'golfer',
-        'DATABASE_URL': 'sqlite:///kahlua.db',
+        "LOGLEVEL": "walter",
+        "DEBUG": "True",
+        "YOURE_NOT_A": "golfer",
+        "DATABASE_URL": "sqlite:///kahlua.db",
     }
 
     cefe = ConfigEnvFileEnv(env_filename)
-    assert cefe.get('not_a', namespace='youre') == 'golfer'
+    assert cefe.get("not_a", namespace="youre") == "golfer"
 
-    cefe = ConfigEnvFileEnv('/does/not/exist/.env')
-    assert cefe.get('loglevel') is NO_VALUE
+    cefe = ConfigEnvFileEnv("/does/not/exist/.env")
+    assert cefe.get("loglevel") is NO_VALUE
 
 
 def test_parse_env_file():
-    assert parse_env_file(['PLAN9=outerspace']) == {'PLAN9': 'outerspace'}
+    assert parse_env_file(["PLAN9=outerspace"]) == {"PLAN9": "outerspace"}
     with pytest.raises(ConfigurationError) as exc_info:
-        parse_env_file(['3AMIGOS=infamous'])
+        parse_env_file(["3AMIGOS=infamous"])
+    assert str(exc_info.value) == 'Invalid variable name "3AMIGOS" in env file (line 1)'
+    with pytest.raises(ConfigurationError) as exc_info:
+        parse_env_file(["INVALID-CHAR=value"])
     assert (
-        str(exc_info.value) ==
-        'Invalid variable name "3AMIGOS" in env file (line 1)'
+        str(exc_info.value)
+        == 'Invalid variable name "INVALID-CHAR" in env file (line 1)'
     )
     with pytest.raises(ConfigurationError) as exc_info:
-        parse_env_file(['INVALID-CHAR=value'])
-    assert (
-        str(exc_info.value) ==
-        'Invalid variable name "INVALID-CHAR" in env file (line 1)'
-    )
-    with pytest.raises(ConfigurationError) as exc_info:
-        parse_env_file(['', 'MISSING-equals'])
-    assert (
-        str(exc_info.value) ==
-        'Env file line missing = operator (line 2)'
-    )
+        parse_env_file(["", "MISSING-equals"])
+    assert str(exc_info.value) == "Env file line missing = operator (line 2)"
 
 
-@pytest.mark.parametrize('key, ns, expected', [
-    ('k', None, 'K'),
-    ('a_b', None, 'A_B'),
-
-    ('k', 'ns', 'NS_K'),
-
-    ('k', ['ns1', 'ns2'], 'NS1_NS2_K'),
-    ('k', ['ns1', '', 'ns2'], 'NS1_NS2_K'),
-])
+@pytest.mark.parametrize(
+    "key, ns, expected",
+    [
+        ("k", None, "K"),
+        ("a_b", None, "A_B"),
+        ("k", "ns", "NS_K"),
+        ("k", ["ns1", "ns2"], "NS1_NS2_K"),
+        ("k", ["ns1", "", "ns2"], "NS1_NS2_K"),
+    ],
+)
 def test_generate_uppercase_key(key, ns, expected):
     full_key = generate_uppercase_key(key, ns)
     assert full_key == expected
 
 
 def test_get_key_from_envs():
-    assert get_key_from_envs({'K': 'v'}, 'K') == 'v'
-    assert get_key_from_envs([{'K': 'v'},
-                              {'L': 'w'}], 'L') == 'w'
-    assert get_key_from_envs({'K': 'v'}, 'Q') is NO_VALUE
+    assert get_key_from_envs({"K": "v"}, "K") == "v"
+    assert get_key_from_envs([{"K": "v"}, {"L": "w"}], "L") == "w"
+    assert get_key_from_envs({"K": "v"}, "Q") is NO_VALUE
     # first match wins
-    envs = [
-        {'K': 'v'},
-        {'L': 'w'},
-        {'K': 'z'},
-    ]
-    assert get_key_from_envs(envs, 'K') == 'v'
+    envs = [{"K": "v"}, {"L": "w"}, {"K": "z"}]
+    assert get_key_from_envs(envs, "K") == "v"
     # works with reversed iterator
-    envs = reversed([{'L': 'v'}, {'L': 'w'}])
-    assert get_key_from_envs(envs, 'L') == 'w'
+    envs = reversed([{"L": "v"}, {"L": "w"}])
+    assert get_key_from_envs(envs, "L") == "w"
     # works with os.environ
-    os.environ['DUDE_ABIDES'] = 'yeah, man'
-    assert get_key_from_envs(os.environ, 'DUDE_ABIDES') == 'yeah, man'
+    os.environ["DUDE_ABIDES"] = "yeah, man"
+    assert get_key_from_envs(os.environ, "DUDE_ABIDES") == "yeah, man"
 
 
 def test_config():
     config = ConfigManager([])
 
     # Don't raise an error and no default yields NO_VALUE
-    assert config('DOESNOTEXISTNOWAY', raise_error=False) is NO_VALUE
+    assert config("DOESNOTEXISTNOWAY", raise_error=False) is NO_VALUE
 
     # Defaults to raising an error
     with pytest.raises(ConfigurationMissingError) as exc_info:
-        config('DOESNOTEXISTNOWAY')
+        config("DOESNOTEXISTNOWAY")
     assert (
-        str(exc_info.value) ==
-        'namespace=None key=DOESNOTEXISTNOWAY requires a value parseable by str'
+        str(exc_info.value)
+        == "namespace=None key=DOESNOTEXISTNOWAY requires a value parseable by str"
     )
 
     # Raises an error if raise_error is True
     with pytest.raises(ConfigurationMissingError) as exc_info:
-        config('DOESNOTEXISTNOWAY', raise_error=True)
+        config("DOESNOTEXISTNOWAY", raise_error=True)
     assert (
-        str(exc_info.value) ==
-        'namespace=None key=DOESNOTEXISTNOWAY requires a value parseable by str'
+        str(exc_info.value)
+        == "namespace=None key=DOESNOTEXISTNOWAY requires a value parseable by str"
     )
 
     # With a default, returns the default
-    assert config('DOESNOTEXISTNOWAY', default='ohreally') == 'ohreally'
+    assert config("DOESNOTEXISTNOWAY", default="ohreally") == "ohreally"
 
     # Test doc
     with pytest.raises(ConfigurationMissingError) as exc_info:
-        config('DOESNOTEXISTNOWAY', doc='Nothing to see here.')
+        config("DOESNOTEXISTNOWAY", doc="Nothing to see here.")
     assert (
-        str(exc_info.value) ==
-        'namespace=None key=DOESNOTEXISTNOWAY requires a value parseable by str\n'
-        'Nothing to see here.'
+        str(exc_info.value)
+        == "namespace=None key=DOESNOTEXISTNOWAY requires a value parseable by str\n"
+        "Nothing to see here."
     )
 
 
 def test_invalidvalueerror():
-    config = ConfigManager.from_dict({
-        'foo_bar': 'bat'
-    })
+    config = ConfigManager.from_dict({"foo_bar": "bat"})
     with pytest.raises(InvalidValueError) as excinfo:
-        config('bar', namespace='foo', parser=bool)
+        config("bar", namespace="foo", parser=bool)
 
-        assert excinfo.value.namespace == 'foo'
-        assert excinfo.value.key == 'bar'
+        assert excinfo.value.namespace == "foo"
+        assert excinfo.value.key == "bar"
         assert excinfo.value.parser == bool
 
 
@@ -411,71 +358,66 @@ def test_configurationmissingerror():
 
     # Defaults to raising an error
     with pytest.raises(ConfigurationMissingError) as exc_info:
-        config('DOESNOTEXISTNOWAY', namespace='foo')
+        config("DOESNOTEXISTNOWAY", namespace="foo")
 
     assert (
-        exc_info.value.args[0] ==
-        'namespace=foo key=DOESNOTEXISTNOWAY requires a value parseable by str'
+        exc_info.value.args[0]
+        == "namespace=foo key=DOESNOTEXISTNOWAY requires a value parseable by str"
     )
-    assert exc_info.value.namespace == 'foo'
-    assert exc_info.value.key == 'DOESNOTEXISTNOWAY'
+    assert exc_info.value.namespace == "foo"
+    assert exc_info.value.key == "DOESNOTEXISTNOWAY"
     assert exc_info.value.parser == str
 
 
 def test_config_from_dict():
     config = ConfigManager.from_dict({})
 
-    assert config('FOO', raise_error=False) is NO_VALUE
+    assert config("FOO", raise_error=False) is NO_VALUE
 
-    config = ConfigManager.from_dict({
-        'FOO': 'bar'
-    })
+    config = ConfigManager.from_dict({"FOO": "bar"})
 
-    assert config('FOO', raise_error=False) == 'bar'
+    assert config("FOO", raise_error=False) == "bar"
 
 
 def test_basic_config(datadir):
-    os.environ['EVERETT_BASIC_CONFIG_TEST'] = 'foo'
-    env_filename = os.path.join(datadir, '.env')
+    os.environ["EVERETT_BASIC_CONFIG_TEST"] = "foo"
+    env_filename = os.path.join(datadir, ".env")
     config = ConfigManager.basic_config(env_filename)
 
     # This doesn't exist in either the environment or the env file
-    assert config('FOO', raise_error=False) is NO_VALUE
+    assert config("FOO", raise_error=False) is NO_VALUE
 
     # This exists in the environment
-    assert config('EVERETT_BASIC_CONFIG_TEST') == 'foo'
+    assert config("EVERETT_BASIC_CONFIG_TEST") == "foo"
 
     # This exists in the env file
-    assert config('LOGLEVEL') == 'walter'
+    assert config("LOGLEVEL") == "walter"
 
 
 def test_config_manager_doc():
     config = ConfigManager(
-        [
-            ConfigDictEnv({'foo': 'bar'}),
-        ],
-        doc='See http://example.com/configuration'
+        [ConfigDictEnv({"foo": "bar"})], doc="See http://example.com/configuration"
     )
 
     # Test ConfigManager doc shows up
     with pytest.raises(ConfigurationError) as exc_info:
-        config('foo', parser=int)
-    assert(
-        str(exc_info.value) ==
-        'ValueError: invalid literal for int() with base 10: \'bar\'\n'
-        'namespace=None key=foo requires a value parseable by int\n'
-        'See http://example.com/configuration'
+        config("foo", parser=int)
+    assert (
+        str(exc_info.value)
+        == "ValueError: invalid literal for int() with base 10: 'bar'\n"
+        "namespace=None key=foo requires a value parseable by int\n"
+        "See http://example.com/configuration"
     )
 
     # Test config doc and ConfigManager doc show up
     with pytest.raises(ConfigurationError) as exc_info:
-        config('foo', parser=int, doc='Port to listen on.')
-    assert(
-        str(exc_info.value) ==
-        'ValueError: invalid literal for int() with base 10: \'bar\'\n'
-        'namespace=None key=foo requires a value parseable by int\n'
-        'Port to listen on.\n'
-        'See http://example.com/configuration'
+        config("foo", parser=int, doc="Port to listen on.")
+    assert (
+        str(exc_info.value)
+        == "ValueError: invalid literal for int() with base 10: 'bar'\n"
+        "namespace=None key=foo requires a value parseable by int\n"
+        "Port to listen on.\n"
+        "See http://example.com/configuration"
     )
 
 
@@ -483,109 +425,107 @@ def test_config_override():
     config = ConfigManager([])
 
     # Make sure the key doesn't exist
-    assert config('DOESNOTEXISTNOWAY', raise_error=False) is NO_VALUE
+    assert config("DOESNOTEXISTNOWAY", raise_error=False) is NO_VALUE
 
     # Try one override
-    with config_override(DOESNOTEXISTNOWAY='bar'):
-        assert config('DOESNOTEXISTNOWAY') == 'bar'
+    with config_override(DOESNOTEXISTNOWAY="bar"):
+        assert config("DOESNOTEXISTNOWAY") == "bar"
 
     # Try nested overrides--innermost one rules supreme!
-    with config_override(DOESNOTEXISTNOWAY='bar'):
-        with config_override(DOESNOTEXISTNOWAY='bat'):
-            assert config('DOESNOTEXISTNOWAY') == 'bat'
+    with config_override(DOESNOTEXISTNOWAY="bar"):
+        with config_override(DOESNOTEXISTNOWAY="bat"):
+            assert config("DOESNOTEXISTNOWAY") == "bat"
 
 
 def test_default_must_be_string():
     config = ConfigManager([])
 
     with pytest.raises(ConfigurationError):
-        assert config('DOESNOTEXIST', default=True)
+        assert config("DOESNOTEXIST", default=True)
 
 
 def test_with_namespace():
-    config = ConfigManager([
-        ConfigDictEnv({
-            'FOO_BAR': 'foobaz',
-            'BAR': 'baz',
-            'BAT': 'bat',
-        })
-    ])
+    config = ConfigManager(
+        [ConfigDictEnv({"FOO_BAR": "foobaz", "BAR": "baz", "BAT": "bat"})]
+    )
 
     # Verify the values first
-    assert config('bar', namespace=['foo']) == 'foobaz'
-    assert config('bar') == 'baz'
-    assert config('bat') == 'bat'
+    assert config("bar", namespace=["foo"]) == "foobaz"
+    assert config("bar") == "baz"
+    assert config("bat") == "bat"
 
     # Create the namespaced config
-    config_with_namespace = config.with_namespace('foo')
-    assert config_with_namespace('bar') == 'foobaz'
+    config_with_namespace = config.with_namespace("foo")
+    assert config_with_namespace("bar") == "foobaz"
 
     # Verify 'bat' is not available because it's not in the namespace
     with pytest.raises(ConfigurationError):
-        config_with_namespace('bat')
+        config_with_namespace("bat")
 
 
 def test_get_namespace():
-    config = ConfigManager.from_dict({
-        'FOO': 'abc',
-        'FOO_BAR': 'abc',
-        'FOO_BAR_BAZ': 'abc',
-    })
+    config = ConfigManager.from_dict(
+        {"FOO": "abc", "FOO_BAR": "abc", "FOO_BAR_BAZ": "abc"}
+    )
     assert config.get_namespace() == []
 
-    ns_foo_config = config.with_namespace('foo')
-    assert ns_foo_config.get_namespace() == ['foo']
+    ns_foo_config = config.with_namespace("foo")
+    assert ns_foo_config.get_namespace() == ["foo"]
 
-    ns_foo_bar_config = ns_foo_config.with_namespace('bar')
-    assert ns_foo_bar_config.get_namespace() == ['foo', 'bar']
+    ns_foo_bar_config = ns_foo_config.with_namespace("bar")
+    assert ns_foo_bar_config.get_namespace() == ["foo", "bar"]
 
 
-@pytest.mark.parametrize('key,alternate_keys,expected', [
-    # key, alternate keys, expected
-    ('FOO', [], 'foo_abc'),
-    ('FOO', ['FOO_BAR'], 'foo_abc'),
-    ('BAD_KEY', ['FOO_BAR'], 'foo_bar_abc'),
-    ('BAD_KEY', ['BAD_KEY1', 'BAD_KEY2', 'FOO_BAR_BAZ'], 'foo_bar_baz_abc'),
-])
+@pytest.mark.parametrize(
+    "key,alternate_keys,expected",
+    [
+        # key, alternate keys, expected
+        ("FOO", [], "foo_abc"),
+        ("FOO", ["FOO_BAR"], "foo_abc"),
+        ("BAD_KEY", ["FOO_BAR"], "foo_bar_abc"),
+        ("BAD_KEY", ["BAD_KEY1", "BAD_KEY2", "FOO_BAR_BAZ"], "foo_bar_baz_abc"),
+    ],
+)
 def test_alternate_keys(key, alternate_keys, expected):
-    config = ConfigManager.from_dict({
-        'FOO': 'foo_abc',
-        'FOO_BAR': 'foo_bar_abc',
-        'FOO_BAR_BAZ': 'foo_bar_baz_abc',
-    })
+    config = ConfigManager.from_dict(
+        {"FOO": "foo_abc", "FOO_BAR": "foo_bar_abc", "FOO_BAR_BAZ": "foo_bar_baz_abc"}
+    )
 
     assert config(key, alternate_keys=alternate_keys) == expected
 
 
-@pytest.mark.parametrize('key,alternate_keys,expected', [
-    # key, alternate keys, expected
-    ('BAR', [], 'foo_bar_abc'),
-    ('BAD_KEY', ['BAD_KEY1', 'BAR_BAZ'], 'foo_bar_baz_abc'),
-    ('bad_key', ['bad_key1', 'bar_baz'], 'foo_bar_baz_abc'),
-    ('bad_key', ['root:common_foo'], 'common_foo_abc')
-])
+@pytest.mark.parametrize(
+    "key,alternate_keys,expected",
+    [
+        # key, alternate keys, expected
+        ("BAR", [], "foo_bar_abc"),
+        ("BAD_KEY", ["BAD_KEY1", "BAR_BAZ"], "foo_bar_baz_abc"),
+        ("bad_key", ["bad_key1", "bar_baz"], "foo_bar_baz_abc"),
+        ("bad_key", ["root:common_foo"], "common_foo_abc"),
+    ],
+)
 def test_alternate_keys_with_namespace(key, alternate_keys, expected):
-    config = ConfigManager.from_dict({
-        'COMMON_FOO': 'common_foo_abc',
-        'FOO': 'foo_abc',
-        'FOO_BAR': 'foo_bar_abc',
-        'FOO_BAR_BAZ': 'foo_bar_baz_abc',
-    })
+    config = ConfigManager.from_dict(
+        {
+            "COMMON_FOO": "common_foo_abc",
+            "FOO": "foo_abc",
+            "FOO_BAR": "foo_bar_abc",
+            "FOO_BAR_BAZ": "foo_bar_baz_abc",
+        }
+    )
 
-    config = config.with_namespace('FOO')
+    config = config.with_namespace("FOO")
 
     assert config(key, alternate_keys=alternate_keys) == expected
 
 
 def test_raw_value():
-    config = ConfigManager.from_dict({
-        'FOO_BAR': '1'
-    })
-    assert config('FOO_BAR', parser=int) == 1
-    assert config('FOO_BAR', parser=int, raw_value=True) == '1'
+    config = ConfigManager.from_dict({"FOO_BAR": "1"})
+    assert config("FOO_BAR", parser=int) == 1
+    assert config("FOO_BAR", parser=int, raw_value=True) == "1"
 
-    assert str(config('NOEXIST', parser=int, raise_error=False)) == 'NO_VALUE'
+    assert str(config("NOEXIST", parser=int, raise_error=False)) == "NO_VALUE"
 
-    config = config.with_namespace('FOO')
-    assert config('BAR', parser=int) == 1
-    assert config('BAR', parser=int, raw_value=True) == '1'
+    config = config.with_namespace("FOO")
+    assert config("BAR", parser=int) == 1
+    assert config("BAR", parser=int, raw_value=True) == "1"

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,5 @@ commands =
 [testenv:py36-lint]
 basepython = python3.6
 commands = pip install -r requirements-dev.txt
+           black --check --target-version=py35 everett tests
            flake8 everett tests


### PR DESCRIPTION
This adds a `Makefile` to simplify some project maintenance. It also adds
black as a dependency and reformats the Python code using it.

Fixes #107