### PR TITLE
Update github actions to drop 3.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,4 @@
+---
 name: CI
 
 on: [push]
@@ -8,35 +9,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    # actions/checkout@v2.0.0
-    - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
+      # actions/checkout@v2.0.0
+      - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
 
-    - name: Set up Python 3.5
-      # actions/setup-python@v1.1.1
-      # Note: Support for 3.5 ends in September 2020.
-      uses: actions/setup-python@28a6c1b915d5808acb3da49af7063544ebfbe085
-      with:
-        python-version: 3.5
+      - name: Set up Python 3.6
+        uses: actions/setup-python@28a6c1b915d5808acb3da49af7063544ebfbe085
+        with:
+          python-version: 3.6
 
-    - name: Set up Python 3.6
-      uses: actions/setup-python@28a6c1b915d5808acb3da49af7063544ebfbe085
-      with:
-        python-version: 3.6
+      - name: Set up Python 3.7
+        uses: actions/setup-python@28a6c1b915d5808acb3da49af7063544ebfbe085
+        with:
+          python-version: 3.7
 
-    - name: Set up Python 3.7
-      uses: actions/setup-python@28a6c1b915d5808acb3da49af7063544ebfbe085
-      with:
-        python-version: 3.7
+      - name: Set up Python 3.8
+        uses: actions/setup-python@28a6c1b915d5808acb3da49af7063544ebfbe085
+        with:
+          python-version: 3.8
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@28a6c1b915d5808acb3da49af7063544ebfbe085
-      with:
-        python-version: 3.8
+      - name: Install CI dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
 
-    - name: Install CI dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
-
-    - name: Run tests
-      run: tox
+      - name: Run tests
+        run: tox


### PR DESCRIPTION
Totally missed this in the last PR. I thought I had set this project to run tox in CI.

Fixes #116.