### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,23 +9,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # actions/checkout@v2.0.0
-      - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
+      - uses: actions/checkout@v2.3.3
 
       - name: Set up Python 3.6
-        uses: actions/setup-python@28a6c1b915d5808acb3da49af7063544ebfbe085
+        uses: actions/setup-python@v2.1.4
         with:
           python-version: 3.6
 
       - name: Set up Python 3.7
-        uses: actions/setup-python@28a6c1b915d5808acb3da49af7063544ebfbe085
+        uses: actions/setup-python@v2.1.4
         with:
           python-version: 3.7
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@28a6c1b915d5808acb3da49af7063544ebfbe085
+        uses: actions/setup-python@v2.1.4
         with:
           python-version: 3.8
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2.1.4
+        with:
+          python-version: 3.9
 
       - name: Install CI dependencies
         run: |

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py36-lint
+envlist = py36,py37,py38,py39,py36-lint
 
 [testenv]
 commands =
@@ -10,5 +10,5 @@ commands =
 [testenv:py36-lint]
 basepython = python3.6
 commands = pip install -r requirements-dev.txt
-           black --check --target-version=py35 everett tests
+           black --check --target-version=py36 everett tests
            flake8 everett tests


### PR DESCRIPTION
This adds support for Python 3.9 and also fixes the py36-lint tox
environment to run black with --target-version=py36.

This also re-pins the GitHub actions to versions rather than commits.

Fixes #117.