### PR TITLE
Fix RemovedInSphinx50Warning regarding ignore argument (#115)

### DIFF
--- a/everett/sphinxext.py
+++ b/everett/sphinxext.py
@@ -381,7 +381,7 @@ class AutoComponentDirective(Directive):
             docstring_attr = self.options["show-docstring"] or "__doc__"
             docstring = getattr(obj, docstring_attr, None)
             if docstring:
-                docstringlines = prepare_docstring(docstring, ignore=1)
+                docstringlines = prepare_docstring(docstring)
                 for i, line in enumerate(docstringlines):
                     self.add_line(indent + line, sourcename, i)
                 self.add_line("", "")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,6 @@ black==20.8b1
 check-manifest==0.44
 flake8==3.8.4
 pytest==6.1.1
-# FIXME(willkg): later versions of Sphinx break the (ridiculous) scaffolding
-# everett does to test the Sphinx extension.
-Sphinx==3.0.4
+Sphinx==3.2.1
 tox==3.20.1
-twine==3.2.0 ; python_version >= '3.6'
+twine==3.2.0


### PR DESCRIPTION
If "ignore" is None, then the code switches it to 1 which is what we were
setting it to. So it seems like the "ignore" argument is being removed
and the behavior is now defaulting to what we want.

Given that, I removed the "ignore" argument from "prepare_docstring".

Fixes #115