### PR TITLE
Fix multiline option doc values in Sphinx autocomponent output (#127)

### DIFF
--- a/everett/__init__.py
+++ b/everett/__init__.py
@@ -9,9 +9,9 @@ __author__ = "Will Kahn-Greene"
 __email__ = "willkg@mozilla.com"
 
 # yyyymmdd
-__releasedate__ = "20201028"
+__releasedate__ = ""
 # x.y.z or x.y.z.dev0
-__version__ = "1.0.3"
+__version__ = "1.0.4.dev0"
 
 
 # _NoValue instances are always false

--- a/everett/sphinxext.py
+++ b/everett/sphinxext.py
@@ -401,7 +401,8 @@ class AutoComponentDirective(Directive):
                     "%s:option %s %s:" % (indent, option["parser"], option["key"]),
                     sourcename,
                 )
-                self.add_line("%s    %s" % (indent, option["doc"]), sourcename)
+                for doc_line in option["doc"].splitlines():
+                    self.add_line("%s    %s" % (indent, doc_line), sourcename)
                 if option["default"] is not NO_VALUE:
                     self.add_line("", "")
                     self.add_line(

--- a/tests/test_sphinxext.py
+++ b/tests/test_sphinxext.py
@@ -363,6 +363,37 @@ def test_option_doc(tmpdir):
     )
 
 
+class ComponentOptionDocMultiline(RequiredConfigMixin):
+    required_config = ConfigOptions()
+    required_config.add_option("user", doc="ou812")
+    required_config.add_option(
+        "password", doc="First ``paragraph``.\n\nSecond paragraph."
+    )
+
+
+def test_option_doc_multiline(tmpdir):
+    rst = dedent(
+        """\
+    .. autocomponent:: test_sphinxext.ComponentOptionDocMultiline
+    """
+    )
+
+    assert parse(tmpdir, rst) == dedent(
+        """\
+        component test_sphinxext.ComponentOptionDocMultiline
+
+           Options:
+              * **user** (*str*) -- ou812
+
+              * **password** (*str*) --
+
+                First "paragraph".
+
+                Second paragraph.
+        """
+    )
+
+
 class ComponentOptionDocDefault(RequiredConfigMixin):
     required_config = ConfigOptions()
     required_config.add_option("user", doc="This is some docs.", default="ou812")


### PR DESCRIPTION
If a config option doc has a value that has multiple lines in it, they
would get glommed into one long line. This fixes that so they get
rendered as multiple pagraphs now.

Fixes #127
