### PR TITLE
Initial scaffolding for type checking (#155)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,5 +36,5 @@ jobs:
           pip install --upgrade pip
           pip install '.[dev]'
 
-      - name: Run tests and linting with tox
+      - name: Run tests, linting, and type checking with tox
         run: tox

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,12 @@ help:
 	@fgrep -h "##" Makefile | fgrep -v fgrep | sed 's/\(.*\):.*##/\1:  /'
 
 .PHONY: test
-test:  ## Run tests
+test:  ## Run tests and static typechecking
 	tox
+
+.PHONY: typecheck
+typecheck:  ## Run typechecking (requires Python 3.8)
+	mypy src/everett/
 
 .PHONY: lint
 lint:  ## Lint and black reformat files
@@ -17,7 +21,7 @@ lint:  ## Lint and black reformat files
 
 .PHONY: clean
 clean:  ## Clean build artifacts
-	rm -rf build dist src/${PROJECT}.egg-info .tox
+	rm -rf build dist src/${PROJECT}.egg-info .tox .pytest_cache .mypy_cache
 	rm -rf docs/_build/*
 	find src/ tests/ -name __pycache__ | xargs rm -rf
 	find src/ tests/ -name '*.pyc' | xargs rm -rf

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,12 @@ filterwarnings =
     ignore:::docutils[.*]
     ignore:::jinja2[.*]
     ignore:::yaml[.*]
+
+[mypy]
+python_version = 3.8
+
+[mypy-configobj.*]
+ignore_missing_imports = True
+
+[mypy-docutils.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,12 @@ EXTRAS_REQUIRE = {
         "black==20.8b1",
         "check-manifest==0.46",
         "flake8==3.9.2",
+        "mypy==0.902",
         "pytest==6.2.4",
         "Sphinx==4.0.2",
         "tox==3.23.1",
         "twine==3.4.1",
+        "types-PyYAML==0.1.7",
     ],
 }
 

--- a/src/everett/sphinxext.py
+++ b/src/everett/sphinxext.py
@@ -126,6 +126,7 @@ You can do that like this::
 """
 
 import sys
+from typing import Dict
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -251,7 +252,7 @@ class EverettDomain(Domain):
     object_types = {"component": ObjType(_("component"), "comp")}
     directives = {"component": EverettComponent}
     roles = {"component": XRefRole(), "comp": XRefRole()}
-    initial_data = {
+    initial_data: Dict[str, dict] = {
         # (typ, clspath) -> sphinx document name
         "objects": {}
     }

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -13,6 +13,7 @@ from everett import (
     ConfigurationMissingError,
     NO_VALUE,
 )
+import everett.manager
 from everett.manager import (
     ConfigDictEnv,
     ConfigEnvFileEnv,
@@ -28,7 +29,31 @@ from everett.manager import (
     parse_bool,
     parse_class,
     parse_env_file,
+    qualname,
 )
+
+
+@pytest.mark.parametrize(
+    "thing, expected",
+    [
+        # built-in
+        (str, "str"),
+        # function in a module
+        (qualname, "everett.manager.qualname"),
+        # module
+        (everett.manager, "everett.manager"),
+        # class
+        (ConfigManager, "everett.manager.ConfigManager"),
+        # class method
+        (ConfigManager.basic_config, "everett.manager.ConfigManager.basic_config"),
+        # instance
+        (ListOf(bool), "<ListOf(bool)>"),
+        # instance method
+        (ConfigOSEnv().get, "everett.manager.ConfigOSEnv.get"),
+    ],
+)
+def test_qualname(thing, expected):
+    assert qualname(thing) == expected
 
 
 def test_no_value():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py36-lint
+envlist = py36,py37,py38,py39,py36-lint,py38-typecheck
 
 [testenv]
 install_command = pip install {packages}
@@ -10,9 +10,13 @@ commands =
 
 [testenv:py36-lint]
 basepython = python3.6
-install_command = pip install {packages}
-extras = dev,ini,yaml
 changedir = {toxinidir}
 commands =
     black --check --target-version=py36 --line-length=88 src tests
     flake8 src tests
+
+[testenv:py38-typecheck]
+basepython = python3.8
+changedir = {toxinidir}
+commands =
+    mypy src/everett/


### PR DESCRIPTION
This adds the initial scaffolding for type checking and fixes existing
issues mypy pointed out.

docutils and configobj don't have type annotations available, so they're
ignored for now. We can change that later when they're available.

This also adds a test for qualname and removes some of the qualname code
that seems like it's from the Python 2 days.