### PR TITLE
flesh out type annotations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ filterwarnings =
 
 [mypy]
 python_version = 3.8
+disallow_untyped_defs = True
 
 [mypy-configobj.*]
 ignore_missing_imports = True

--- a/src/everett/__init__.py
+++ b/src/everett/__init__.py
@@ -71,3 +71,9 @@ class InvalidValueError(DetailedConfigurationError):
     """Error that indicates that the value is not valid."""
 
     pass
+
+
+class EverettComponent:
+    """Type for Everett components that use RequiredConfigMixin."""
+
+    pass

--- a/src/everett/__init__.py
+++ b/src/everett/__init__.py
@@ -5,6 +5,9 @@
 
 """Everett is a Python library for configuration."""
 
+from typing import Callable, List, Union
+
+
 __author__ = "Will Kahn-Greene"
 __email__ = "willkg@mozilla.com"
 
@@ -16,13 +19,13 @@ __version__ = "1.0.4.dev0"
 
 # _NoValue instances are always false
 class NoValue:
-    def __nonzero__(self):
+    def __nonzero__(self) -> bool:
         return False
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "NO_VALUE"
 
 
@@ -45,14 +48,17 @@ class InvalidKeyError(ConfigurationError):
 class DetailedConfigurationError(ConfigurationError):
     """Base class for configuration errors that have a msg, namespace, key, and parser."""
 
-    def __init__(self, *args, **kwargs):
-        self.namespace = args[1]
-        self.key = args[2]
-        self.parser = args[3]
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self, msg: str, namespace: Union[List[str], None], key: str, parser: Callable
+    ):
+        self.msg = msg
+        self.namespace = namespace
+        self.key = key
+        self.parser = parser
+        super().__init__(msg, namespace, key, parser)
 
-    def __str__(self):
-        return self.args[0]
+    def __str__(self) -> str:
+        return self.msg
 
 
 class ConfigurationMissingError(DetailedConfigurationError):

--- a/src/everett/__init__.py
+++ b/src/everett/__init__.py
@@ -15,7 +15,7 @@ __version__ = "1.0.4.dev0"
 
 
 # _NoValue instances are always false
-class _NoValue:
+class NoValue:
     def __nonzero__(self):
         return False
 
@@ -27,7 +27,7 @@ class _NoValue:
 
 
 # Singleton indicating a non-value
-NO_VALUE = _NoValue()
+NO_VALUE = NoValue()
 
 
 class ConfigurationError(Exception):

--- a/src/everett/component.py
+++ b/src/everett/component.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 from collections.abc import Mapping
 from typing import Any, Callable, Dict, Generator, Iterator, List, Tuple, Union
 
-from everett import NO_VALUE, NoValue
+from everett import EverettComponent, NO_VALUE, NoValue
 from everett.manager import BoundConfig
 
 
@@ -104,7 +104,7 @@ class ConfigOptions(Mapping):
         return len(self.options)
 
 
-class RequiredConfigMixin:
+class RequiredConfigMixin(EverettComponent):
     """Mixin for component classes that have required configuration.
 
     As with all mixins, make sure this is earlier in the class list.

--- a/src/everett/component.py
+++ b/src/everett/component.py
@@ -6,7 +6,17 @@
 
 from collections import OrderedDict
 from collections.abc import Mapping
-from typing import Any, Callable, Dict, Generator, Iterator, List, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 from everett import EverettComponent, NO_VALUE, NoValue
 from everett.manager import BoundConfig
@@ -18,8 +28,8 @@ class Option:
     def __init__(
         self,
         key: str,
-        default: Any = NO_VALUE,
-        alternate_keys: Union[List[str], NoValue] = NO_VALUE,
+        default: Union[str, NoValue] = NO_VALUE,
+        alternate_keys: Optional[List[str]] = None,
         doc: str = "",
         parser: Callable = str,
         meta: Any = None,
@@ -52,8 +62,8 @@ class ConfigOptions(Mapping):
     def add_option(
         self,
         key: str,
-        default: Any = NO_VALUE,
-        alternate_keys: Union[List[str], NoValue] = NO_VALUE,
+        default: Union[str, NoValue] = NO_VALUE,
+        alternate_keys: Optional[List[str]] = None,
         doc: str = "",
         parser: Callable = str,
         **meta: Any,

--- a/src/everett/component.py
+++ b/src/everett/component.py
@@ -5,8 +5,10 @@
 """Module holding infrastructure for building components."""
 
 from collections import OrderedDict
+from collections.abc import Mapping
+from typing import Any, Callable, Dict, Generator, Iterator, List, Tuple, Union
 
-from everett import NO_VALUE
+from everett import NO_VALUE, NoValue
 from everett.manager import BoundConfig
 
 
@@ -15,12 +17,12 @@ class Option:
 
     def __init__(
         self,
-        key,
-        default=NO_VALUE,
-        alternate_keys=NO_VALUE,
-        doc="",
-        parser=str,
-        meta=None,
+        key: str,
+        default: Any = NO_VALUE,
+        alternate_keys: Union[List[str], NoValue] = NO_VALUE,
+        doc: str = "",
+        parser: Callable = str,
+        meta: Any = None,
     ):
         self.key = key
         self.default = default
@@ -29,7 +31,7 @@ class Option:
         self.parser = parser
         self.meta = meta or {}
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: Any) -> bool:
         return (
             isinstance(obj, Option)
             and obj.key == self.key
@@ -41,15 +43,21 @@ class Option:
         )
 
 
-class ConfigOptions:
-    """A collection of config options."""
+class ConfigOptions(Mapping):
+    """A mapping of config options."""
 
-    def __init__(self):
-        self.options = OrderedDict()
+    def __init__(self) -> None:
+        self.options: Dict = OrderedDict()
 
     def add_option(
-        self, key, default=NO_VALUE, alternate_keys=NO_VALUE, doc="", parser=str, **meta
-    ):
+        self,
+        key: str,
+        default: Any = NO_VALUE,
+        alternate_keys: Union[List[str], NoValue] = NO_VALUE,
+        doc: str = "",
+        parser: Callable = str,
+        **meta: Any,
+    ) -> None:
         """Add an option to the group.
 
         :arg key: the key to look up
@@ -79,18 +87,21 @@ class ConfigOptions:
         )
         self.options[key] = option
 
-    def update(self, new_options):
+    def update(self, new_options: List[Option]) -> None:
         """Update this ConfigOptions using data from another."""
         for option in new_options:
             if option.key in self.options:
                 del self.options[option.key]
             self.options[option.key] = option
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Option]:
         return iter(self.options.values())
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Option:
         return self.options.__getitem__(key)
+
+    def __len__(self) -> int:
+        return len(self.options)
 
 
 class RequiredConfigMixin:
@@ -117,7 +128,7 @@ class RequiredConfigMixin:
     """
 
     @classmethod
-    def get_required_config(cls):
+    def get_required_config(cls) -> ConfigOptions:
         """Roll up configuration options for this class and parent classes.
 
         This handles subclasses overriding options in parent classes.
@@ -128,13 +139,13 @@ class RequiredConfigMixin:
         """
         options = ConfigOptions()
         for cls in reversed(cls.__mro__):
-            try:
-                options.update(cls.required_config)
-            except AttributeError:
-                pass
+            if hasattr(cls, "required_config"):
+                options.update(getattr(cls, "required_config"))
         return options
 
-    def get_runtime_config(self, namespace=None):
+    def get_runtime_config(
+        self, namespace: Union[List[str], None] = None
+    ) -> Generator[Tuple[Union[List[str], None], str, Any, Option], None, None]:
         """Roll up the runtime config for this class and all children.
 
         Implement this to call ``.get_runtime_config()`` on child components or
@@ -185,6 +196,6 @@ class RequiredConfigMixin:
             yield (
                 namespace,
                 opt.key,
-                self.config(opt.key, raise_error=False, raw_value=True),
+                cfg(opt.key, raise_error=False, raw_value=True),
                 opt,
             )

--- a/src/everett/ext/inifile.py
+++ b/src/everett/ext/inifile.py
@@ -12,17 +12,18 @@ To use this, you must install the optional requirements::
 
 import logging
 import os
+from typing import Dict, List, Optional, Union
 
 from configobj import ConfigObj
 
-from everett import NO_VALUE
+from everett import NO_VALUE, NoValue
 from everett.manager import generate_uppercase_key, get_key_from_envs, listify
 
 
 logger = logging.getLogger("everett")
 
 
-class ConfigIniEnv(object):
+class ConfigIniEnv:
     """Source for pulling configuration from INI files.
 
     This requires optional dependencies. You can install them with::
@@ -121,7 +122,7 @@ class ConfigIniEnv(object):
 
     """
 
-    def __init__(self, possible_paths):
+    def __init__(self, possible_paths: Union[str, List[str]]) -> None:
         self.cfg = {}
         self.path = None
         possible_paths = listify(possible_paths)
@@ -139,11 +140,11 @@ class ConfigIniEnv(object):
         if not self.path:
             logger.debug("No INI file found: %s", possible_paths)
 
-    def parse_ini_file(self, path):
+    def parse_ini_file(self, path: str) -> Dict:
         """Parse ini file at ``path`` and return dict."""
         cfgobj = ConfigObj(path, list_values=False)
 
-        def extract_section(namespace, d):
+        def extract_section(namespace: List[str], d: Dict) -> Dict:
             cfg = {}
             for key, val in d.items():
                 if isinstance(d[key], dict):
@@ -155,7 +156,9 @@ class ConfigIniEnv(object):
 
         return extract_section([], cfgobj.dict())
 
-    def get(self, key, namespace=None):
+    def get(
+        self, key: str, namespace: Optional[List[str]] = None
+    ) -> Union[str, NoValue]:
         """Retrieve value for key."""
         if not self.path:
             return NO_VALUE
@@ -166,5 +169,5 @@ class ConfigIniEnv(object):
         full_key = generate_uppercase_key(key, namespace)
         return get_key_from_envs(self.cfg, full_key)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<ConfigIniEnv: %s>" % self.path

--- a/src/everett/ext/yamlfile.py
+++ b/src/everett/ext/yamlfile.py
@@ -12,17 +12,18 @@ To use this, you must install the optional requirements::
 
 import logging
 import os
+from typing import Dict, List, Optional, Union
 
 import yaml
 
-from everett import ConfigurationError, NO_VALUE
+from everett import ConfigurationError, NO_VALUE, NoValue
 from everett.manager import generate_uppercase_key, get_key_from_envs, listify
 
 
 logger = logging.getLogger("everett")
 
 
-class ConfigYamlEnv(object):
+class ConfigYamlEnv:
     """Source for pulling configuration from YAML files.
 
     This requires optional dependencies. You can install them with::
@@ -108,7 +109,7 @@ class ConfigYamlEnv(object):
 
     """
 
-    def __init__(self, possible_paths):
+    def __init__(self, possible_paths: Union[str, List[str]]) -> None:
         self.cfg = {}
         self.path = None
         possible_paths = listify(possible_paths)
@@ -126,7 +127,7 @@ class ConfigYamlEnv(object):
         if not self.path:
             logger.debug("No YAML file found: %s", possible_paths)
 
-    def parse_yaml_file(self, path):
+    def parse_yaml_file(self, path: str) -> Dict:
         """Parse yaml file at ``path`` and return a dict."""
         with open(path, "r") as fp:
             data = yaml.safe_load(fp)
@@ -134,7 +135,7 @@ class ConfigYamlEnv(object):
         if not data:
             return {}
 
-        def traverse(namespace, d):
+        def traverse(namespace: List[str], d: Dict) -> Dict:
             cfg = {}
             for key, val in d.items():
                 if isinstance(val, dict):
@@ -154,7 +155,9 @@ class ConfigYamlEnv(object):
 
         return traverse([], data)
 
-    def get(self, key, namespace=None):
+    def get(
+        self, key: str, namespace: Optional[List[str]] = None
+    ) -> Union[str, NoValue]:
         """Retrieve value for key."""
         if not self.path:
             return NO_VALUE
@@ -163,5 +166,5 @@ class ConfigYamlEnv(object):
         full_key = generate_uppercase_key(key, namespace)
         return get_key_from_envs(self.cfg, full_key)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<ConfigYamlEnv: %s>" % self.path

--- a/src/everett/sphinxext.py
+++ b/src/everett/sphinxext.py
@@ -126,7 +126,7 @@ You can do that like this::
 """
 
 import sys
-from typing import Dict
+from typing import Any, Dict, List, Optional, Union
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -144,7 +144,7 @@ from everett import NO_VALUE, __version__
 from everett.manager import qualname
 
 
-def split_clspath(clspath):
+def split_clspath(clspath: str) -> List[str]:
     """Split clspath into module and class names.
 
     Note: This is a really simplistic implementation.
@@ -153,7 +153,7 @@ def split_clspath(clspath):
     return clspath.rsplit(".", 1)
 
 
-def import_class(clspath):
+def import_class(clspath: str) -> Any:
     """Given a clspath, returns the class.
 
     Note: This is a really simplistic implementation.
@@ -165,7 +165,7 @@ def import_class(clspath):
     return getattr(module, clsname)
 
 
-def upper_lower_none(arg):
+def upper_lower_none(arg: Optional[str]) -> Union[str, None]:
     """Validate arg value as "upper", "lower", or None."""
     if not arg:
         return arg
@@ -193,7 +193,8 @@ class EverettComponent(ObjectDescription):
 
     allow_nesting = False
 
-    def handle_signature(self, sig, signode):
+    # FIXME(willkg): What's the signode here?
+    def handle_signature(self, sig: str, signode: Any) -> str:
         """Create a signature for this thing."""
         if sig != "Configuration":
             signode.clear()
@@ -218,7 +219,8 @@ class EverettComponent(ObjectDescription):
 
         return sig
 
-    def add_target_and_index(self, name, sig, signode):
+    # FIXME(willkg): What's the signode here?
+    def add_target_and_index(self, name: str, sig: str, signode: Any) -> None:
         """Add a target and index for this thing."""
         targetname = f"{self.objtype}-{name}"
 
@@ -257,17 +259,19 @@ class EverettDomain(Domain):
         "objects": {}
     }
 
-    def clear_doc(self, docname):
+    def clear_doc(self, docname: str) -> None:
         for (typ, name), doc in list(self.data["objects"].items()):
             if doc == docname:
                 del self.data["objects"][typ, name]
 
-    def merge_domaindata(self, docnames, otherdata):
+    # FIXME(willkg): What's the value in otherdata dict?
+    def merge_domaindata(self, docnames: List[str], otherdata: Dict[str, Any]) -> None:
         for (typ, name), doc in otherdata["objects"].items():
             if doc in docnames:
                 self.data["objects"][typ, name] = doc
 
-    def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
+    # FIXME(willkg): what're args and return type here?
+    def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):  # type: ignore
         objects = self.data["objects"]
         objtypes = self.objtypes_for_role(typ) or []
 
@@ -318,11 +322,12 @@ class AutoComponentDirective(Directive):
         "case": upper_lower_none,
     }
 
-    def add_line(self, line, source, *lineno):
+    def add_line(self, line: str, source: str, *lineno: int) -> None:
         """Add a line to the result"""
         self.result.append(line, source, *lineno)
 
-    def generate_docs(self, clspath, more_content):
+    # FIXME(willkg): what is more_content?
+    def generate_docs(self, clspath: str, more_content: Any) -> None:
         """Generate documentation for this configman class"""
         obj = import_class(clspath)
         sourcename = "docstring of %s" % clspath
@@ -413,7 +418,8 @@ class AutoComponentDirective(Directive):
                     )
                 self.add_line("", "")
 
-    def run(self):
+    # FIXME(willkg): this returns a list of nodes
+    def run(self) -> List[Any]:
         self.reporter = self.state.document.reporter
         self.result = ViewList()
 
@@ -428,7 +434,8 @@ class AutoComponentDirective(Directive):
         return node.children
 
 
-def setup(app):
+# FIXME(willkg): this takes a Sphinx app
+def setup(app: Any) -> Dict[str, Any]:
     """Register domain and directive in Sphinx."""
     app.add_domain(EverettDomain)
     app.add_directive("autocomponent", AutoComponentDirective)


### PR DESCRIPTION
This goes through the code and fleshes out the type annotations. I think I got most of them more-or-less right-ish except `sphinxext.py` where I threw in a bunch of `Any` because I didn't want to spend the time to pour over the docutils and Sphinx code to figure out what those things are.

Fixes #155 