### PR TITLE
Improve autocomponent documentation with example

### DIFF
--- a/docs/code/recipes_appconfig.py
+++ b/docs/code/recipes_appconfig.py
@@ -16,8 +16,8 @@ def parse_loglevel(value):
         return text_to_level[value.upper()]
     except KeyError:
         raise ValueError(
-            '"%s" is not a valid logging level. Try CRITICAL, ERROR, '
-            "WARNING, INFO, DEBUG" % value
+            f'"{value}" is not a valid logging level. Try CRITICAL, ERROR, '
+            "WARNING, INFO, DEBUG"
         )
 
 
@@ -27,13 +27,16 @@ class AppConfig(RequiredConfigMixin):
         "debug",
         parser=bool,
         default="false",
-        doc="Turns on debug mode for the applciation",
+        doc="Turns on debug mode for the application",
     )
     required_config.add_option(
         "loglevel",
         parser=parse_loglevel,
         default="INFO",
-        doc="Log level for the application",
+        doc=(
+            "Log level for the application; CRITICAL, ERROR, WARNING, INFO, "
+            "DEBUG"
+        ),
     )
 
     def __init__(self, config):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,9 +19,14 @@ import os
 import sys
 
 cwd = os.getcwd()
+
+# Add ../src/ directory so we can pull in Everett things using autodoc
 project_root = os.path.dirname(cwd)
 src_root = os.path.join(project_root, "src")
 sys.path.insert(0, src_root)
+
+# Add code/ directory so we can use autocomponent with a recipe
+sys.path.insert(0, os.path.join(cwd, "code/"))
 
 import everett  # noqa
 
@@ -36,6 +41,7 @@ import everett  # noqa
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "everett.sphinxext",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/documenting.rst
+++ b/docs/documenting.rst
@@ -19,5 +19,23 @@ in your Sphinx-generated docs without having to manually update it.
 Further, Everett components will show up in the index making it easier for users
 to find what they're looking for.
 
+For example, with this code:
+
+.. literalinclude:: code/recipes_appconfig.py
+
+
+You can add this to your docs::
+
+    .. autocomponent:: recipes_appconfig.AppConfig
+       :hide-classname:
+       :case: upper
+
+And get this:
+
+.. autocomponent:: recipes_appconfig.AppConfig
+   :hide-classname:
+   :case: upper
+
+Module docs:
 
 .. automodule:: everett.sphinxext


### PR DESCRIPTION
This adds an example of using an Everett component with the autocomponent Sphinx directive and what you get from it.