### PR TITLE
Fix docs requirements file for readthedocs building

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,3 @@
--e ..[dev,ini,yaml]
+# NOTE: this gets run during the RTD build from the parent directory with:
+# python -m pip install --exists-action=w --no-cache-dir -r docs/requirements.txt
+-e .[dev,ini,yaml]


### PR DESCRIPTION
ReadTheDocs uses the project directory as the root when installing the
docs/requirements.txt file, so the relative paths need to be based on
the project directory.