### PR TITLE
Fix Sphinx warning (#165)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ max-line-length = 88
 filterwarnings =
     error
     ignore:::babel[.*]
-    ignore:::docutils[.*]
     ignore:::jinja2[.*]
     ignore:::yaml[.*]
 

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,9 @@ EXTRAS_REQUIRE = {
         "pytest==6.2.4",
         "Sphinx==4.1.2",
         "sphinx_rtd_theme==0.5.2",
-        "tox==3.24.0",
+        "tox==3.24.3",
         "twine==3.4.2",
-        "types-PyYAML==5.4.3",
+        "types-PyYAML==5.4.6",
     ],
 }
 

--- a/src/everett/sphinxext.py
+++ b/src/everett/sphinxext.py
@@ -185,7 +185,7 @@ class EverettComponent(ObjectDescription):
             "options",
             label=_("Options"),
             names=("option", "opt"),
-            typerolename="obj",
+            typerolename="parser",
             typenames=("parser",),
             can_collapse=True,
         )
@@ -253,7 +253,12 @@ class EverettDomain(Domain):
 
     object_types = {"component": ObjType(_("component"), "comp")}
     directives = {"component": EverettComponent}
-    roles = {"component": XRefRole(), "comp": XRefRole()}
+    roles = {
+        "component": XRefRole(),
+        "comp": XRefRole(),
+        "option": XRefRole(),
+        "parser": XRefRole(),
+    }
     initial_data: Dict[str, dict] = {
         # (typ, clspath) -> sphinx document name
         "objects": {}


### PR DESCRIPTION
This fixes a warning Sphinx 4.1 and later spit out when using the
Everett sphinx extension. This adds a role for parsers and switches to
using that.

Fixes #165