### PR TITLE
Update dev reqs and support Python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,33 +8,26 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+
+    name: Python ${{ matrix.python-version}}
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.3.5
 
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v2.2.1
+      - name: Set up Python
+        uses: actions/setup-python@v2.2.2
         with:
-          python-version: 3.6
+          python-version: ${{ matrix.python-version }}
 
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2.2.1
-        with:
-          python-version: 3.7
-
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2.2.1
-        with:
-          python-version: 3.8
-
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2.2.1
-        with:
-          python-version: 3.9
-
-      - name: Install dev dependencies
+      - name: Update pip and install dev requirements
         run: |
-          pip install --upgrade pip
-          pip install '.[dev]'
+          python -m pip install --upgrade pip
+          pip install '.[dev,datadog.statsd]'
 
-      - name: Run tests, linting, and type checking with tox
+      - name: Lint
+        run: make lint
+
+      - name: Test
         run: tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,8 @@ filterwarnings =
     ignore:::babel[.*]
     ignore:::jinja2[.*]
     ignore:::yaml[.*]
+    # Sphinx 4.2.0 uses distutils and it's deprecated in 3.10
+    ignore::DeprecationWarning:sphinx
 
 [mypy]
 python_version = 3.8

--- a/setup.py
+++ b/setup.py
@@ -28,15 +28,16 @@ EXTRAS_REQUIRE = {
     "yaml": ["PyYAML"],
     "dev": [
         "black==20.8b1",
-        "check-manifest==0.46",
-        "flake8==3.9.2",
+        "check-manifest==0.47",
+        "flake8==4.0.1",
         "mypy==0.910",
-        "pytest==6.2.4",
-        "Sphinx==4.1.2",
-        "sphinx_rtd_theme==0.5.2",
-        "tox==3.24.3",
+        "pytest==6.2.5",
+        "Sphinx==4.2.0",
+        "sphinx_rtd_theme==1.0.0",
+        "tox==3.24.4",
+        "tox-gh-actions==2.8.1",
         "twine==3.4.2",
-        "types-PyYAML==5.4.6",
+        "types-PyYAML==6.0.0",
     ],
 }
 
@@ -67,6 +68,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     project_urls={
         "Documentation": "https://everett.readthedocs.io/",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,13 @@
 [tox]
-envlist = py36,py37,py38,py39,py36-lint,py38-typecheck
+envlist = py36,py37,py38,py39,py310,py36-lint,py38-typecheck
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
 
 [testenv]
 install_command = pip install {packages}


### PR DESCRIPTION
This updates the dev requirements for Everett.

This changes our CI to use a Python version matrix strategy.

This adds support for Python 3.10. It was mostly straight-forward except
that Sphinx 4.2.0 uses distutils which throws a DeprecationWarning in
our test suite. I had to add an explicit ignore for that.

Fixes #173