### PR TITLE
Overhaul sphinx extension; support module configuration docs (#172)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,15 +1,40 @@
 History
 =======
 
-2.1.0 (In development)
+3.0.0 (In development)
 ----------------------
 
 Backwards incompatible changes:
 
 * Dropped support for Python 3.6. (#176)
 
+* Dropped ``autocomponent`` Sphinx directive in favor of
+  ``autocomponentconfig``.
 
-Fixes:
+Fixes and features:
+
+* Add support for Python 3.10. (#173)
+
+* Rework namespaces so that you can apply a namespace (``with_namespace()``)
+  after binding a component (``with_options()``) (#175)
+
+* Overhauled, simplified, and improved documentation. Files with example output
+  are now generated using `cog <https://pypi.org/project/cogapp/>`_.
+
+* Rewrite Sphinx extension.
+
+  This now supports manually documenting configuration using
+  ``everett:component`` and ``everett:option`` directives.
+
+  This adds ``:everett:component:`` and ``:everett:option:`` roles for linking
+  to specific configuration in the docs.
+
+  It also addsh ``autocomponentconfig`` and ``automoduleconfig`` directives for
+  automatically generating documentation.
+
+  When using these directives, items are added to the index and everything is
+  linkable making it easier to find and talk to users about specific
+  configuration items. (#172)
 
 
 2.0.1 (August, 23rd, 2021)

--- a/README.rst
+++ b/README.rst
@@ -29,8 +29,9 @@ From that, Everett has the following features:
   and writing your own configuration environments
 * facilitates helpful error messages for users trying to configure your
   software
-* supports automated documentation of configuration with a Sphinx
-  ``autocomponent`` directive
+* has a Sphinx extension for documenting configuration including
+  ``autocomponentconfig`` and ``automoduleconfig`` directives for
+  automatically generating configuration documentation
 * facilitates testing of configuration values
 * supports parsing values of a variety of types like bool, int, lists of
   things, classes, and others and lets you write your own parsers
@@ -181,4 +182,4 @@ Most other libraries I looked at had one or more of the following issues:
 * provided poor error messages when users configure things wrong
 * had a global configuration object
 * made it really hard to override specific configuration when writing tests
-* had no facilities for auto-generating configuration documentation
+* had no facilities for autogenerating configuration documentation

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -1,3 +1,6 @@
+.. NOTE: Make sure to edit the template for this file in docs_tmpl/ and
+.. not the cog-generated version.
+
 ==========
 Components
 ==========
@@ -68,9 +71,9 @@ Centrally defining configuration like this helps in a few ways:
    of spread out across your code base.
 
 3. You can automatically document your configuration using the
-   ``everett.sphinxext`` Sphinx extension and ``autocomponent`` directive::
+   ``everett.sphinxext`` Sphinx extension and ``autocomponentconfig`` directive::
 
-       .. autocomponent:: path.to.AppConfig
+       .. autocomponentconfig:: path.to.AppConfig
 
    Because it's automatically documented, your documentation is always
    up-to-date.
@@ -103,11 +106,11 @@ a set of buckets?
     for name in dest_config:
         dest_buckets.append(S3Bucket(s3_config.with_namespace(name)))
 
-You can auto-generate configuration documentation for this component in your
+You can autogenerate configuration documentation for this component in your
 Sphinx docs by including the ``everett.sphinxext`` Sphinx extension and
-using the ``autocomponent`` directive::
+using the ``autocomponentconfig`` directive::
 
-    .. autocomponent:: myapp.S3Bucket
+    .. autocomponentconfig:: myapp.S3Bucket
 
 
 Subclassing

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ project_root = os.path.dirname(cwd)
 src_root = os.path.join(project_root, "src")
 sys.path.insert(0, src_root)
 
-# Add ../examples/ directory so we can use autocomponent with a recipe
+# Add ../examples/ directory so we can use autocomponentconfig with a recipe
 sys.path.insert(0, os.path.join(project_root, "examples"))
 
 import everett  # noqa

--- a/docs/configmanager.rst
+++ b/docs/configmanager.rst
@@ -1,3 +1,6 @@
+.. NOTE: Make sure to edit the template for this file in docs_tmpl/ and
+.. not the cog-generated version.
+
 ======================
 Configuration Managers
 ======================

--- a/docs/documenting.rst
+++ b/docs/documenting.rst
@@ -1,35 +1,296 @@
-===========
-Documenting
-===========
+=========================
+Documenting configuration
+=========================
+
+.. contents::
+   :local:
 
 It's hard to keep configuration documentation up-to-date as projects change
 over time.
 
 Everett comes with a `Sphinx <https://http://www.sphinx-doc.org/en/stable/>`_
-extension to make it easier to document Everett components and configuration.
-This allows you to write configuration code and have it automatically documented
-in your Sphinx-generated docs without having to manually update it.
+extension for documenting configuration. It has ``autocomponentconfig`` and
+``automoduleconfig`` directives for automatically generating documentation. It
+also has ``everett:component`` and ``everett:option`` directives for manually
+documenting configuration. It also comes with ``:everett:option:`` and
+``:everett:component:`` roles letting you create links to specific
+configuration things in your documentation.
 
-Further, Everett components will show up in the index making it easier for users
-to find what they're looking for.
+Configuration options are added to the index and have unique links making it
+easier to find and point people to specific configuration documentation.
 
-For example, with this code:
+.. versionchanged:: 3.0.0
+   Complete rewrite of Sphinx directives.
+
+
+Directives
+==========
+
+.. rst:directive:: automoduleconfig
+
+   **Requires Python 3.8 or higher.**
+
+   Automatically documents the configuration options set in a Python module
+   using the specified :py:class:`everett.manager.ConfigManager`.
+
+   The argument is the Python dotted path to the
+   :py:class:`everett.manager.ConfigManager` instance.
+
+   .. Note::
+
+      The automoduleconfig directive works by parsing the Python module as an
+      AST and then traverses the AST. It does not execute the module, so it
+      doesn't evaluate any values.
+
+   .. rubric:: Options
+
+   .. rst:directive:option:: show-table
+      :type: no value
+
+      If set, will create a table summarizing the options in this module with
+      links to the option details.
+
+   .. rst:directive:option:: hide-name
+      :type: no value
+
+      If set, this will hide the name derived from the Python dotted path
+      and use "Configuration" instead.
+
+      This affects how the options are indexed. If you're documenting multiple
+      modules this way, options that exist in multiple modules will create a
+      conflict.
+
+   .. rst:directive:option:: show-docstring
+      :type: str, empty str, or omitted
+
+      If omitted, this does nothing.
+
+      If set, but with no value, this will include the module docstring in
+      the documentation.
+
+      If set with a value of the name of an attribute in the module, this will
+      include the value of that attribute in the documentation.
+
+      Example to include the module ``__doc__``:
+
+      ::
+
+          .. automoduleconfig:: myproject.settings._config
+             :show-docstring:
+    
+      Example to include the value of the value of the ``HELP`` attribute:
+
+      ::
+
+          .. automoduleconfig:: myproject.settings._config
+             :show-docstring: HELP
+
+   .. rst:directive:option:: namespace
+      :type: str
+
+      If set, this prefixes all the option keys with the specified namespace.
+      
+      For example, if you set namespace to ``source_db``, then key ``host``
+      would result in ``source_db_host`` being documented. (Case is dependent
+      on the "case" directive option.)
+
+   .. rst:directive:option:: case
+      :type: "upper", "lower", or omitted
+
+      Specifies whether to convert the full namespaced key to all uppercase,
+      all lowercase, or leave it as is.
+
+
+.. rst:directive:: autocomponentconfig
+
+   Automatically documents the configuration options for the specified class
+   and its superclasses.
+
+   The argument is the Python dotted path to the class.
+
+   .. Warning::
+
+      ``autocomponentconfig`` **imports** the code to be documented. If any of
+      the imported modules have side-effects at import, they will be executed
+      when building the documentation.
+
+   .. rubric:: Options
+
+   .. rst:directive:option:: show-table
+      :type: no value
+
+      If set, will create a table summarizing the options in this component
+      with links to the option details.
+
+   .. rst:directive:option:: hide-name
+      :type: no value
+
+      If set, this will hide the name of the class and use "Configuration"
+      instead.
+
+      This affects how the options are indexed. If you're documenting multiple
+      classes this way, options that exist in multiple classes will create a
+      conflict.
+
+   .. rst:directive:option:: show-docstring
+      :type: str, empty str, or omitted
+
+      If omitted, this does nothing.
+
+      If set, but with no value, this will include the class docstring in the
+      documentation.
+
+      If set with a value of the name of an attribute of the class, this will
+      include the value of that attribute in the documentation.
+
+      Example to include the class docstring:
+
+      ::
+
+          .. automoduleconfig:: myproject.MyClass
+             :show-docstring:
+    
+      Example to include the value of the value of the ``HELP`` attribute:
+
+      ::
+
+          .. automoduleconfig:: myproject.MyClass
+             :show-docstring: HELP
+
+   .. rst:directive:option:: namespace
+      :type: str
+
+      If set, this prefixes all the option keys with the specified namespace.
+      
+      For example, if you set namespace to ``source_db``, then key ``host``
+      would result in ``source_db_host`` being documented. (Case is dependent
+      on the "case" directive option.)
+
+   .. rst:directive:option:: case
+      :type: "upper", "lower", or omitted
+
+      Specifies whether to convert the full namespaced key to all uppercase,
+      all lowercase, or leave it as is.
+
+
+.. rst:directive:: everett:component
+
+   Defines an Everett component which is any Python class that has an inner
+   class named ``Config`` which defines configuration options.
+
+   The argument is the Python dotted path to the class.
+
+   Add ``everett:option`` as part of the description.
+
+
+.. rst:directive:: everett:option
+
+   Defines an Everett configuration option.
+
+   The argument is the option key.
+
+   .. rubric:: Options
+
+   .. rst:directive:option:: parser
+      :type: str
+
+      The name of the parser for this option.
+
+   .. rst:directive:option:: default
+      :type: str
+
+      If not set, the default is ``NO_VALUE`` which means that this option has
+      no default value.
+
+      If set, this is the default value. Enclose the value in double-quotes
+      because all default values must be strings.
+
+   .. rst:directive:option:: required
+      :type: no value
+
+      If set, this option is required.
+
+      If not set and the option has a default, then this option is not
+      required.
+
+      If not set and the option has no default, then this option is required.
+
+      This option is not required::
+
+          .. everett:option:: HOST
+             :default: localhost
+
+      These two options are required::
+
+          .. everett:option:: USERNAME
+             
+          .. everett:option:: PASSWORD
+             :required:
+
+
+Examples
+========
+
+Documenting component configuration
+-----------------------------------
+
+Here's an example Everett component:
 
 .. literalinclude:: ../examples/recipes_appconfig.py
 
 
-You can add this to your docs::
+You can use the ``autocomponentconfig`` directive to extract the configuration
+information from the ``AppConfig`` class and document it::
 
-    .. autocomponent:: recipes_appconfig.AppConfig
-       :hide-classname:
+    .. autocomponentconfig:: recipes_appconfig.AppConfig
        :case: upper
+       :show-table:
 
-And get this:
 
-.. autocomponent:: recipes_appconfig.AppConfig
-   :hide-classname:
+That gives you something that looks like this:
+
+.. autocomponentconfig:: recipes_appconfig.AppConfig
    :case: upper
+   :show-table:
 
-Module docs:
 
-.. automodule:: everett.sphinxext
+You can link to components with the ``:everett:component:`` role and options
+using the ``:everett:option:`` role.
+
+Examples::
+
+    Component link: :everett:component:`recipes_appconfig.AppConfig`
+
+    Option link: :everett:option:`recipes_appconfig.AppConfig.DEBUG`
+
+Component link: :everett:component:`recipes_appconfig.AppConfig`
+
+Option link: :everett:option:`recipes_appconfig.AppConfig.DEBUG`
+
+
+
+Documenting module configuration
+--------------------------------
+
+You can use ``automoduleconfig`` to document configuration that's set at module
+import. This is helpful for Django settings modules.
+
+Example configuration code that sets up a
+:py:class:`everett.manager.ConfigManager` and calls it ``_config``:
+
+.. literalinclude:: ../examples/recipes_djangosettings.py
+   :language: python
+
+Example documentation directive::
+
+    .. automoduleconfig:: recipes_djangosettings._config
+       :hide-name:
+       :case: upper
+       :show-table:
+
+That gives you this:
+
+.. automoduleconfig:: recipes_djangosettings._config
+   :hide-name:
+   :case: upper
+   :show-table:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,4 +26,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -39,9 +39,10 @@ for the application:
 
 
 Couple of nice things here. First, is that if you do Sphinx documentation, you
-can use ``autocomponent`` to automatically document your configuration based on
-the code. Second, you can use :py:func:`everett.manager.get_runtime_config` to
-print out the runtime configuration at startup.
+can use ``autocomponentconfig`` to automatically document your configuration
+based on the code. Second, you can use
+:py:func:`everett.manager.get_runtime_config` to print out the runtime
+configuration at startup.
 
 
 Using components that share configuration by passing arguments

--- a/docs_tmpl/README.rst
+++ b/docs_tmpl/README.rst
@@ -29,8 +29,9 @@ From that, Everett has the following features:
   and writing your own configuration environments
 * facilitates helpful error messages for users trying to configure your
   software
-* supports automated documentation of configuration with a Sphinx
-  ``autocomponent`` directive
+* has a Sphinx extension for documenting configuration including
+  ``autocomponentconfig`` and ``automoduleconfig`` directives for
+  automatically generating configuration documentation
 * facilitates testing of configuration values
 * supports parsing values of a variety of types like bool, int, lists of
   things, classes, and others and lets you write your own parsers
@@ -176,4 +177,4 @@ Most other libraries I looked at had one or more of the following issues:
 * provided poor error messages when users configure things wrong
 * had a global configuration object
 * made it really hard to override specific configuration when writing tests
-* had no facilities for auto-generating configuration documentation
+* had no facilities for autogenerating configuration documentation

--- a/docs_tmpl/components.rst
+++ b/docs_tmpl/components.rst
@@ -91,9 +91,9 @@ Centrally defining configuration like this helps in a few ways:
    of spread out across your code base.
 
 3. You can automatically document your configuration using the
-   ``everett.sphinxext`` Sphinx extension and ``autocomponent`` directive::
+   ``everett.sphinxext`` Sphinx extension and ``autocomponentconfig`` directive::
 
-       .. autocomponent:: path.to.AppConfig
+       .. autocomponentconfig:: path.to.AppConfig
 
    Because it's automatically documented, your documentation is always
    up-to-date.
@@ -126,11 +126,11 @@ a set of buckets?
     for name in dest_config:
         dest_buckets.append(S3Bucket(s3_config.with_namespace(name)))
 
-You can auto-generate configuration documentation for this component in your
+You can autogenerate configuration documentation for this component in your
 Sphinx docs by including the ``everett.sphinxext`` Sphinx extension and
-using the ``autocomponent`` directive::
+using the ``autocomponentconfig`` directive::
 
-    .. autocomponent:: myapp.S3Bucket
+    .. autocomponentconfig:: myapp.S3Bucket
 
 
 Subclassing

--- a/examples/recipes_djangosettings.py
+++ b/examples/recipes_djangosettings.py
@@ -1,0 +1,11 @@
+# recipes_djangosettings.py
+
+from everett.manager import ConfigManager
+
+
+_config = ConfigManager.basic_config()
+
+
+DEBUG = _config(
+    "debug", parser=bool, default="False", doc="Whether or not DEBUG mode is enabled."
+)

--- a/src/everett/__init__.py
+++ b/src/everett/__init__.py
@@ -14,7 +14,7 @@ __email__ = "willkg@mozilla.com"
 # yyyymmdd
 __releasedate__ = ""
 # x.y.z or x.y.z.dev0
-__version__ = "2.1.0.dev0"
+__version__ = "3.0.0.dev0"
 
 
 __all__ = [

--- a/src/everett/sphinxext.py
+++ b/src/everett/sphinxext.py
@@ -2,146 +2,39 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""Sphinx extension for auto-documenting components with configuration.
+"""Sphinx extension for auto-documenting components with configuration."""
 
-The ``autocomponent`` declaration will pull out the class docstring as well as
-configuration requirements, throw it all in a blender and spit it out.
-
-To configure Sphinx, add ``'everett.sphinxext'`` to the ``extensions`` in
-``conf.py``::
-
-    extensions = [
-        ...
-        'everett.sphinxext'
-    ]
-
-
-.. Note::
-
-   You need to make sure that Everett is installed in the environment
-   that Sphinx is being run in.
-
-Use it like this in an reStructuredText file to document a component::
-
-    .. autocomponent:: collector.ext.s3.S3CrashStorage
-
-
-You can refer to that component in other parts of your docs and get a link
-by using the ``:everett:component:`` role::
-
-    Check out the :everett:component:`collector.ext.s3.S3CrashStorage`
-    configuration.
-
-
-If your component class names are unique, then you can probably get away with::
-
-    Check out the :everett:component:`S3CrashStorage` configuration.
-
-
-.. versionchanged:: 0.9
-
-   In Everett 0.8 and prior, the extension was in the
-   ``everett.sphinx_autoconfig`` module and the directive was ``..
-   autoconfig::``.
-
-
-**Showing docstring and content**
-
-If you want the docstring for the class, you can specify ``:show-docstring:``::
-
-    .. autocomponent:: collector.external.boto.crashstorage.BotoS3CrashStorage
-       :show-docstring:
-
-
-If you want to show help, but from a different attribute than the docstring,
-you can specify any class attribute::
-
-    .. autocomponent:: collector.external.boto.crashstorage.BotoS3CrashStorage
-       :show-docstring: __everett_help__
-
-
-You can provide content as well::
-
-    .. autocomponent:: collector.external.boto.crashstorage.BotoS3CrashStorage
-
-       This is some content!
-
-.. versionadded:: 0.5
-
-
-**Hiding the class name**
-
-You can hide the class name if you want::
-
-    .. autocomponent:: collector.external.boto.crashstorage.BotoS3CrashStorage
-       :hide-classname:
-
-
-This is handy for application-level configuration where you might not want to
-confuse users with how it's implemented.
-
-.. versionadded:: 0.5
-
-
-**Prepending the namespace**
-
-If you have a component that only gets used with one namespace, then it will
-probably help users if the documentation includes the full configuration key
-with the namespace prepended.
-
-You can do that like this::
-
-    .. autocomponent:: collector.external.boto.crashstorage.BotoS3CrashStorage
-       :namespace: crashstorage
-
-
-Then the docs will show keys like ``crashstorage_foo`` rather than just
-``foo``.
-
-.. versionadded:: 0.8
-
-
-**Showing keys as uppercased or lowercased**
-
-If your project primarily depends on configuration from OS environment
-variables, then you probably want to document those variables with the keys
-shown as uppercased.
-
-You can do that like this::
-
-    .. autocomponent:: collector.external.boto.crashstorage.BotoS3CrashStorage
-       :case: upper
-
-
-If your project primarily depends on configuration from INI files, then you
-probably want to document those variables with keys shown as lowercased.
-
-You can do that like this::
-
-    .. autocomponent:: collector.external.boto.crashstorage.BotoS3CrashStorage
-       :case: lower
-
-.. versionadded:: 0.8
-
-"""
-
-import sys
-from typing import Any, Dict, List, Optional, Union
+import ast
+from importlib import import_module
+import re
+import textwrap
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
-from docutils.statemachine import ViewList
+from docutils.statemachine import ViewList, StringList
 from sphinx import addnodes
+from sphinx.addnodes import desc_signature, pending_xref
 from sphinx.directives import ObjectDescription
 from sphinx.domains import Domain, ObjType
 from sphinx.locale import _
 from sphinx.roles import XRefRole
-from sphinx.util.docfields import TypedField
+from sphinx.util import ws_re
+from sphinx.util import logging
+from sphinx.util.docfields import Field
 from sphinx.util.docstrings import prepare_docstring
 from sphinx.util.nodes import make_refnode
 
 from everett import NO_VALUE, __version__
 from everett.manager import qualname, get_config_for_class
+
+
+if TYPE_CHECKING:
+    from sphinx.builders import Builder
+    from sphinx.environment import BuildEnvironment
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def split_clspath(clspath: str) -> List[str]:
@@ -153,16 +46,49 @@ def split_clspath(clspath: str) -> List[str]:
     return clspath.rsplit(".", 1)
 
 
+def get_module_and_objpath(path: str) -> Any:
+    """Given a path, imports the module part of the path and returns the module
+    and the rest of the path.
+
+    :arg clspath: a "a.b.c.Class" style path
+
+    :returns: "a.b.c" module and "Class"
+
+    """
+    parts = path.split(".")
+
+    # Figure out the module
+    for i in range(len(parts)):
+        modpath = parts[:i]
+        objpath = parts[i:]
+        if not modpath:
+            continue
+
+        try:
+            module = import_module(".".join(modpath))
+        except ImportError:
+            break
+
+    return module, ".".join(objpath)
+
+
 def import_class(clspath: str) -> Any:
     """Given a clspath, returns the class.
 
     Note: This is a really simplistic implementation.
 
+    :arg clspath: a "a.b.c.Class" style path
+
+    :returns: the Class
+
     """
-    modpath, clsname = split_clspath(clspath)
-    __import__(modpath)
-    module = sys.modules[modpath]
-    return getattr(module, clsname)
+    module, objpath = get_module_and_objpath(clspath)
+
+    obj = module
+    for part in objpath.split(","):
+        obj = getattr(obj, part)
+
+    return obj
 
 
 def upper_lower_none(arg: Optional[str]) -> Union[str, None]:
@@ -177,16 +103,96 @@ def upper_lower_none(arg: Optional[str]) -> Union[str, None]:
     raise ValueError('argument must be "upper", "lower" or None')
 
 
+class EverettOption(ObjectDescription):
+    """An Everett config option."""
+
+    indextemplate = "everett option; %s"
+
+    option_spec = {
+        # This is the parser for the option
+        "parser": directives.unchanged_required,
+        # The default for this option; no value (not NO_VALUE--that's different) is
+        # treated as an empty string
+        "default": directives.unchanged_required,
+        # Whether or not this option is required
+        "required": directives.flag,
+    }
+
+    def handle_signature(self, sig: str, signode: desc_signature) -> str:
+        signode.clear()
+        signode += addnodes.desc_name(sig, sig)
+        name = ws_re.sub(" ", sig)
+        return name
+
+    def add_target_and_index(
+        self, name: str, sig: str, signode: desc_signature
+    ) -> None:
+        ref = self.env.ref_context.get("everett:component")
+        if ref:
+            targetname = f"{self.objtype}-{ref}.{name}"
+            # If this is in a component, we change the name to include the
+            # component name
+            name = f"{ref}.{name}"
+        else:
+            targetname = f"{self.objtype}-{name}"
+
+        if targetname not in self.state.document.ids:
+            signode["names"].append(targetname)
+            signode["ids"].append(targetname)
+            signode["first"] = not self.names
+            self.state.document.note_explicit_target(signode)
+
+            objects = self.env.domaindata["everett"]["objects"]
+            key = (self.objtype, name)
+            if key in objects:
+                self.state_machine.reporter.warning(
+                    f"duplicate description of {self.objtype} {name!r}, "
+                    + f"other instance in {self.env.doc2path(objects[key][0])}",
+                    line=self.lineno,
+                )
+
+            objects[key] = (self.env.docname, targetname)
+
+        indextext = _("%s (component)") % name
+        self.indexnode["entries"].append(("single", indextext, targetname, "", None))
+
+    def transform_content(self, contentnode: addnodes.desc_content) -> None:
+        # We want to insert some stuff before the content
+
+        lines = StringList()
+
+        sourcename = "everett option"
+
+        parser = self.options.get("parser", "str")
+        default = self.options.get("default")
+        is_required = ("required" in self.options) or (default is None)
+        required = "Yes" if is_required else "No"
+
+        lines.append(f":Parser: *{parser}*", sourcename)
+
+        if default is not None:
+            lines.append(f":Default: {default}", sourcename)
+
+        lines.append(f":Required: {required}", sourcename)
+        lines.append("", sourcename)
+
+        node = nodes.paragraph()
+        node.document = self.state.document
+        self.state.nested_parse(lines, 0, node)
+
+        # Insert  our new nodes before the rest of the content
+        contentnode.children = node.children + contentnode.children
+
+
 class EverettComponent(ObjectDescription):
     """Description of an Everett component."""
 
     doc_field_types = [
-        TypedField(
+        Field(
             "options",
+            names=("option",),
             label=_("Options"),
-            names=("option", "opt"),
-            typenames=("parser",),
-            can_collapse=True,
+            rolename="option",
         )
     ]
 
@@ -218,8 +224,9 @@ class EverettComponent(ObjectDescription):
 
         return sig
 
-    # FIXME(willkg): What's the signode here?
-    def add_target_and_index(self, name: str, sig: str, signode: Any) -> None:
+    def add_target_and_index(
+        self, name: str, sig: str, signode: desc_signature
+    ) -> None:
         """Add a target and index for this thing."""
         targetname = f"{self.objtype}-{name}"
 
@@ -233,15 +240,21 @@ class EverettComponent(ObjectDescription):
             key = (self.objtype, name)
             if key in objects:
                 self.state_machine.reporter.warning(
-                    f"duplicate description of {self.objtype} {name}, "
-                    + "other instance in "
-                    + self.env.doc2path(objects[key]),
+                    f"duplicate description of {self.objtype} {name!r}, "
+                    + f"other instance in {self.env.doc2path(objects[key][0])}",
                     line=self.lineno,
                 )
-            objects[key] = self.env.docname
+            objects[key] = (self.env.docname, targetname)
 
         indextext = _("%s (component)") % name
         self.indexnode["entries"].append(("single", indextext, targetname, "", None))
+
+    def before_content(self) -> None:
+        if self.names:
+            self.env.ref_context["everett:component"] = self.names[-1]
+
+    def after_content(self) -> None:
+        self.env.ref_context["everett:component"] = None
 
 
 class EverettDomain(Domain):
@@ -250,8 +263,14 @@ class EverettDomain(Domain):
     name = "everett"
     label = "Everett"
 
-    object_types = {"component": ObjType(_("component"), "component")}
-    directives = {"component": EverettComponent}
+    object_types = {
+        "component": ObjType(_("component"), "component"),
+        "option": ObjType(_("option"), "option"),
+    }
+    directives = {
+        "component": EverettComponent,
+        "option": EverettOption,
+    }
     roles = {
         "component": XRefRole(),
         "option": XRefRole(),
@@ -261,51 +280,145 @@ class EverettDomain(Domain):
         "objects": {}
     }
 
+    @property
+    def objects(self) -> Dict[Tuple[str, str], Tuple[str, str]]:
+        return self.data.setdefault("objects", {})
+
     def clear_doc(self, docname: str) -> None:
-        for (typ, name), doc in list(self.data["objects"].items()):
-            if doc == docname:
-                del self.data["objects"][typ, name]
+        key: Any = None
+        for key, val in list(self.objects.items()):
+            if val[0] == docname:
+                del self.objects[key]
 
     # FIXME(willkg): What's the value in otherdata dict?
     def merge_domaindata(self, docnames: List[str], otherdata: Dict[str, Any]) -> None:
-        for (typ, name), doc in otherdata["objects"].items():
-            if doc in docnames:
-                self.data["objects"][typ, name] = doc
+        for key, val in otherdata["objects"].items():
+            if val[0] in docnames:
+                self.objects[key] = val
 
-    # FIXME(willkg): what're args and return type here?
-    def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):  # type: ignore
-        objects = self.data["objects"]
+    def resolve_xref(
+        self,
+        env: "BuildEnvironment",
+        fromdocname: str,
+        builder: "Builder",
+        typ: str,
+        target: str,
+        node: pending_xref,
+        contnode: nodes.Element,
+    ) -> Optional[nodes.Element]:
+
         objtypes = self.objtypes_for_role(typ) or []
-
         for objtype in objtypes:
-            for (typ, clspath) in objects:
-                # Look up using the full classpath
-                if (objtype, target) == (typ, clspath):
-                    return make_refnode(
-                        builder,
-                        fromdocname,
-                        objects[typ, clspath],
-                        objtype + "-" + target,
-                        contnode,
-                        target + " " + objtype,
+            if (objtype, target) in self.objects:
+                docname, labelid = self.objects[objtype, target]
+                break
+
+        else:
+            docname, labelid = "", ""
+
+        if docname:
+            return make_refnode(builder, fromdocname, docname, labelid, contnode)
+
+        return None
+
+
+class ConfigDirective(Directive):
+    """Base class for generating configuration"""
+
+    def add_line(self, line: str, source: str, *lineno: int) -> None:
+        """Add a line to the result"""
+        self.result.append(line, source, *lineno)
+        # NOTE(willkg): This makes figuring out issues easier. Leaving it here
+        # for future me.
+        # if line.strip():
+        #     print(f">>> {line} [{source} {lineno}]")
+        # else:
+        #     print(">>> ")
+
+    def generate_docs(
+        self,
+        component_name: str,
+        component_index: str,
+        docstring: str,
+        sourcename: str,
+        option_data: List[Dict],
+        more_content: Any,
+    ) -> None:
+
+        indent = "   "
+
+        # Add the classname or 'Configuration'
+        self.add_line(".. everett:component:: %s" % component_name, sourcename)
+        self.add_line("", sourcename)
+
+        # Add the docstring if there is one and if show-docstring
+        if "show-docstring" in self.options and docstring:
+            docstringlines = prepare_docstring(docstring)
+            for i, line in enumerate(docstringlines):
+                self.add_line(indent + line, sourcename, i)
+            self.add_line("", "")
+
+        # Add content from the directive if there was any
+        if more_content:
+            for line, src in zip(more_content.data, more_content.items):
+                self.add_line(indent + line, src[0], src[1])
+            self.add_line("", "")
+
+        if "show-table" in self.options:
+            self.add_line(indent + "Configuration summary:", sourcename)
+            self.add_line("", sourcename)
+
+            # First build a table of metric items
+            table: List[List[str]] = []
+            table.append(["Setting", "Parser", "Required?"])
+            for option_item in option_data:
+                ref = f"{component_name}.{option_item['key']}"
+                table.append(
+                    [
+                        f":everett:option:`{option_item['key']} <{ref}>`",
+                        f"*{option_item['parser']}*",
+                        "Yes" if option_item["default"] is NO_VALUE else "",
+                    ]
+                )
+
+            for line in build_table(table):
+                self.add_line(indent + line, sourcename)
+
+            self.add_line("", sourcename)
+
+            self.add_line(indent + "Configuration options:", sourcename)
+            self.add_line("", sourcename)
+
+        if option_data:
+            # Now list the options
+            sourcename = "class definition"
+
+            for option_item in option_data:
+                key = option_item["key"]
+                self.add_line(f"{indent}.. everett:option:: {key}", sourcename)
+
+                self.add_line(
+                    f"{indent}   :parser: {option_item['parser']}", sourcename
+                )
+                if option_item["default"] is not NO_VALUE:
+                    self.add_line(
+                        f"{indent}   :default: \"{option_item['default']}\"", sourcename
                     )
+                else:
+                    self.add_line(f"{indent}   :required:", sourcename)
+                self.add_line("", sourcename)
 
-                # Try looking it up by the class name--this lets people use
-                # shorthand in their roles
-                if "." in clspath:
-                    modname, clsname = split_clspath(clspath)
-                    if (objtype, target) == (typ, clsname):
-                        return make_refnode(
-                            builder,
-                            fromdocname,
-                            objects[typ, clspath],
-                            objtype + "-" + clspath,
-                            contnode,
-                            target + " " + objtype,
-                        )
+                doc = option_item["doc"]
+                for doc_line in doc.splitlines():
+                    self.add_line(f"{indent}   {doc_line}", sourcename)
+
+                self.add_line("", sourcename)
+        self.add_line("", sourcename)
 
 
-class AutoComponentDirective(Directive):
+class AutoComponentConfigDirective(ConfigDirective):
+    """Directive for documenting configuration for an Everett component."""
+
     has_content = True
     required_arguments = 1
     optional_arguments = 0
@@ -317,50 +430,72 @@ class AutoComponentDirective(Directive):
         # the attribute on the class
         "show-docstring": directives.unchanged,
         # Whether or not to hide the class name
-        "hide-classname": directives.flag,
+        "hide-name": directives.flag,
         # Prepend a specified namespace
         "namespace": directives.unchanged,
         # Render keys in specified case
         "case": upper_lower_none,
+        # Whether or not to show a table
+        "show-table": directives.flag,
     }
 
-    def add_line(self, line: str, source: str, *lineno: int) -> None:
-        """Add a line to the result"""
-        self.result.append(line, source, *lineno)
+    def extract_configuration(
+        self,
+        obj: Any,
+        namespace: Optional[str] = None,
+        case: Optional[str] = None,
+    ) -> List[Dict]:
+        """Extracts configuration values from list of Everett configuration options
 
-    # FIXME(willkg): what is more_content?
-    def generate_docs(self, clspath: str, more_content: Any) -> None:
-        """Generate documentation for this configman class"""
-        obj = import_class(clspath)
-        sourcename = "docstring of %s" % clspath
-        all_options = []
-        indent = "    "
+        :param obj: object/class to extract configuration from
+        :param namespace: namespace if any that these options are in
+        :param case: None, "upper", or "lower" for converting the name
+
+        :returns: list of dicts each representing an option
+
+        """
         config = get_config_for_class(obj)
+        options: List[Dict] = []
 
-        if config:
-            # Go through options and figure out relevant information
-            for key, (option, cls) in config.items():
-                if "namespace" in self.options:
-                    namespaced_key = self.options["namespace"] + "_" + key
-                else:
-                    namespaced_key = key
+        # Go through options and figure out relevant information
+        for key, (option, cls) in config.items():
+            if namespace:
+                namespaced_key = namespace + "_" + key
+            else:
+                namespaced_key = key
 
-                if "case" in self.options:
-                    if self.options["case"] == "upper":
-                        namespaced_key = namespaced_key.upper()
-                    elif self.options["case"] == "lower":
-                        namespaced_key = namespaced_key.lower()
+            if case == "upper":
+                namespaced_key = namespaced_key.upper()
+            elif case == "lower":
+                namespaced_key = namespaced_key.lower()
 
-                all_options.append(
-                    {
-                        "key": namespaced_key,
-                        "parser": qualname(option.parser),
-                        "doc": option.doc,
-                        "default": option.default,
-                    }
-                )
+            options.append(
+                {
+                    "key": namespaced_key,
+                    "default": option.default,
+                    "parser": qualname(option.parser),
+                    "doc": option.doc,
+                    "meta": {},
+                }
+            )
+        return options
 
-        if "hide-classname" not in self.options:
+    def run(self) -> List[nodes.Node]:
+        self.reporter = self.state.document.reporter
+        self.result = ViewList()
+
+        clspath = self.arguments[0]
+
+        obj = import_class(clspath)
+        sourcename = "configuration of %s" % clspath
+
+        option_data = self.extract_configuration(
+            obj=obj,
+            namespace=self.options.get("namespace"),
+            case=self.options.get("case"),
+        )
+
+        if "hide-name" not in self.options:
             modname, clsname = split_clspath(clspath)
             component_name = clspath
             component_index = clsname
@@ -368,68 +503,283 @@ class AutoComponentDirective(Directive):
             component_name = "Configuration"
             component_index = "Configuration"
 
-        if all_options:
-            # Add index entries for options first so they link to the right
-            # place; we do it this way so that we don't have to make options a
-            # real object type and then we don't get to use TypedField
-            # formatting
-            self.add_line(".. index::", sourcename)
-            for option_item in all_options:
-                self.add_line(
-                    "   single: {}; ({})".format(option_item["key"], component_index),
-                    sourcename,
-                )
-            self.add_line("", "")
-
-        # Add the classname or 'Configuration'
-        self.add_line(".. everett:component:: %s" % component_name, sourcename)
-        self.add_line("", sourcename)
-
         # Add the docstring if there is one and if show-docstring
         if "show-docstring" in self.options:
             docstring_attr = self.options["show-docstring"] or "__doc__"
-            docstring = getattr(obj, docstring_attr, None)
-            if docstring:
-                docstringlines = prepare_docstring(docstring)
-                for i, line in enumerate(docstringlines):
-                    self.add_line(indent + line, sourcename, i)
-                self.add_line("", "")
+            docstring = getattr(obj, docstring_attr, "")
+        else:
+            docstring = ""
 
-        # Add content from the directive if there was any
-        if more_content:
-            for line, src in zip(more_content.data, more_content.items):
-                self.add_line(indent + line, src[0], src[1])
-            self.add_line("", "")
+        self.generate_docs(
+            component_name=component_name,
+            component_index=component_index,
+            docstring=docstring,
+            sourcename=sourcename,
+            option_data=option_data,
+            more_content=self.content,
+        )
 
-        if all_options:
-            # Now list the options
-            sourcename = "class definition"
+        if not self.result:
+            return []
 
-            for option_item in all_options:
-                self.add_line(
-                    "{}:option {} {}:".format(
-                        indent, option_item["parser"], option_item["key"]
-                    ),
-                    sourcename,
-                )
-                for doc_line in option_item["doc"].splitlines():
-                    self.add_line(f"{indent}    {doc_line}", sourcename)
-                if option_item["default"] is not NO_VALUE:
-                    self.add_line("", "")
-                    self.add_line(
-                        "{}    Defaults to ``{!r}``.".format(
-                            indent, option_item["default"]
-                        ),
-                        sourcename,
-                    )
-                self.add_line("", "")
+        node = nodes.paragraph()
+        node.document = self.state.document
+        self.state.nested_parse(self.result, 0, node)
+        return node.children
 
-    # FIXME(willkg): this returns a list of nodes
-    def run(self) -> List[Any]:
+
+SETTING_RE = re.compile(r"^[A-Z_]+$")
+
+
+def build_table(table: List[List[str]]) -> List[str]:
+    """Generates reST for a table.
+
+    :param table: a 2d array of rows and columns
+
+    :returns: list of strings
+
+    """
+    output: List[str] = []
+
+    col_size = [0] * len(table[0])
+    for row in table:
+        for i, col in enumerate(row):
+            col_size[i] = max(col_size[i], len(col))
+
+    col_size = [width + 2 for width in col_size]
+
+    # Build header
+    output.append("  ".join("=" * width for width in col_size))
+    output.append(
+        "  ".join(
+            header + (" " * (width - len(header)))
+            for header, width in zip(table[0], col_size)
+        )
+    )
+    output.append("  ".join("=" * width for width in col_size))
+
+    # Iterate through rows
+    for row in table[1:]:
+        output.append(
+            "  ".join(
+                col + (" " * (width - len(col))) for col, width in zip(row, col_size)
+            )
+        )
+    output.append("  ".join("=" * width for width in col_size))
+    return output
+
+
+def get_value_from_ast_node(source: str, val: ast.AST) -> str:
+    """Wrapper for ast.get_source_segment.
+
+    NOTE(willkg): ``ast.get_source_segment()`` was implemented in Python 3.8 and
+    when we drop support for Python 3.6 and 3.7, we can drop this code, too.
+
+    This is to get the source code for the AST node in question so that we can
+    display it as is in the docs. For a wildly contrived example, if you did
+    something bizarre like::
+
+        config = ConfigManager.basic_config()
+        DEBUG = config("debug, parser=bool, default="False")
+        WEIRD = config("weird", parser=(bool if config("debug") else int))
+
+    then the node for ``bool if config("debug") else int`` will be an
+    ``ast.IfEq`` (or something like that) and this function will return::
+
+       bool if config("debug") else int
+
+    and show that as the parser in the docs.
+
+    :param source: the complete source text for the file being parsed
+    :param val: the ast node in question
+
+    :returns: a string representation of the ast node for display in docs
+
+    """
+    if hasattr(ast, "get_source_segment"):
+        return ast.get_source_segment(source, val) or "?"
+
+    # If we have < Python 3.8, return a "?" because it's not clear what it is.
+    # Python 3.6 and 3.7 don't have end_lineno and end_col_offset either, so I
+    # couldn't figure out a good way to figure out the source segment to
+    # return.
+    return "?"
+
+
+class AutoModuleConfigDirective(ConfigDirective):
+    """Directive for documenting configuration for a module."""
+
+    has_content = True
+    # path/to/module.py variablename
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = False
+
+    option_spec = {
+        # Whether or not to show the class docstring--if None, don't show the
+        # docstring, if empty string use __doc__, otherwise use the value of
+        # the attribute on the class
+        "show-docstring": directives.unchanged,
+        # Whether or not to hide the name
+        "hide-name": directives.flag,
+        # Prepend a specified namespace
+        "namespace": directives.unchanged,
+        # Render keys in specified case
+        "case": upper_lower_none,
+        # Whether or not to show a table
+        "show-table": directives.flag,
+    }
+
+    def extract_configuration(
+        self,
+        filepath: str,
+        variable_name: str,
+        namespace: Optional[str] = None,
+        case: Optional[str] = None,
+    ) -> List[Dict]:
+        """Extracts configuration values from a module at filepath
+
+        :param filepath: the filepath to parse configuration from
+        :param variable_name: the ConfigurationManager variable name
+        :param namespace: namespace if any that these options are in
+        :param case: None, "upper", or "lower" for converting the name
+
+        :returns: list of dicts each representing an option
+
+        """
+        with open(filepath) as fp:
+            source = fp.read()
+
+        tree = ast.parse(source=source, filename=filepath, mode="exec")
+        config_nodes = [
+            (node.targets[0].id, node.value)
+            for node in tree.body
+            if (
+                isinstance(node, ast.Assign)
+                and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
+                and SETTING_RE.match(node.targets[0].id)
+                and isinstance(node.value, ast.Call)
+                and isinstance(node.value.func, ast.Name)
+                and node.value.func.id == variable_name
+            )
+        ]
+
+        CONFIG_ARGS = [
+            "key",
+            "default",
+            "parser",
+            "doc",
+            "meta",
+        ]
+
+        def extract_value(source: str, val: ast.AST) -> Tuple[str, str]:
+            """Returns (category, value)"""
+            if isinstance(val, ast.Constant):
+                return "constant", val.value
+            if isinstance(val, ast.Name):
+                return "name", val.id
+            return "unknown", get_value_from_ast_node(source, val)
+
+        # Using a dict here avoids the case where configuration options are
+        # defined multiple times
+        configuration = {}
+
+        for node in config_nodes:
+            name = node[0]
+            args: Dict[str, Any] = {
+                "key": name,
+                "default": NO_VALUE,
+                "parser": "str",
+                "doc": "",
+                "meta": {},
+            }
+            for i, arg in enumerate(node[1].args):
+                cat, value = extract_value(source, arg)
+
+                # NOTE(willkg): we're dropping the cat here; but we might want
+                # to do something with the category in the future, so I'm
+                # leaving the figuring in for now
+                args[CONFIG_ARGS[i]] = value
+
+            for keyword in node[1].keywords:
+                # NOTE(willkg): mypy thinks this can be None for some reason,
+                # but I'm not sure why. If it is None, we should skip it.
+                if keyword.arg is None:
+                    continue
+
+                cat, value = extract_value(source, keyword.value)
+                value = "" if value is None else value
+                if keyword.arg == "doc":
+                    value = textwrap.dedent(value)
+
+                # NOTE(willkg): we're dropping the cat here; but we might want
+                # to do something with the category in the future, so I'm
+                # leaving the figuring in for now
+                args[keyword.arg] = value
+
+            key = args["key"]
+            if namespace:
+                namespaced_key = f"{namespace}_{key}"
+            else:
+                namespaced_key = key
+
+            if case == "upper":
+                namespaced_key = namespaced_key.upper()
+            elif case == "lower":
+                namespaced_key = namespaced_key.lower()
+
+            args["key"] = namespaced_key
+            configuration[name] = args
+
+        return list(configuration.values())
+
+    def run(self) -> List[nodes.Node]:
         self.reporter = self.state.document.reporter
         self.result = ViewList()
 
-        self.generate_docs(self.arguments[0], self.content)
+        clspath = self.arguments[0]
+
+        module, objpath = get_module_and_objpath(clspath)
+        filepath = module.__file__
+        variable_name = objpath
+
+        if not variable_name:
+            raise ValueError("Variable in module is unknown")
+
+        sourcename = "configuration of %s" % clspath
+
+        option_data = self.extract_configuration(
+            filepath=filepath,
+            variable_name=variable_name,
+            namespace=self.options.get("namespace"),
+            case=self.options.get("case"),
+        )
+
+        if "hide-name" not in self.options:
+            modname, clsname = split_clspath(clspath)
+            component_name = clspath
+            component_index = clsname
+        else:
+            component_name = "Configuration"
+            component_index = "Configuration"
+
+        # Add the docstring if there is one and if show-docstring
+        if "show-docstring" in self.options:
+            obj = module
+            docstring_attr = self.options["show-docstring"] or "__doc__"
+            docstring = getattr(obj, docstring_attr, "")
+        else:
+            docstring = ""
+
+        self.generate_docs(
+            component_name=component_name,
+            component_index=component_index,
+            docstring=docstring,
+            sourcename=sourcename,
+            option_data=option_data,
+            more_content=self.content,
+        )
 
         if not self.result:
             return []
@@ -444,7 +794,8 @@ class AutoComponentDirective(Directive):
 def setup(app: Any) -> Dict[str, Any]:
     """Register domain and directive in Sphinx."""
     app.add_domain(EverettDomain)
-    app.add_directive("autocomponent", AutoComponentDirective)
+    app.add_directive("autocomponentconfig", AutoComponentConfigDirective)
+    app.add_directive("automoduleconfig", AutoModuleConfigDirective)
 
     return {
         "version": __version__,

--- a/tests/basic_component_config.py
+++ b/tests/basic_component_config.py
@@ -1,0 +1,81 @@
+"""Basic component config."""
+
+from everett.manager import ListOf, Option, parse_class
+
+
+class ComponentBasic:
+    """Basic component.
+
+    Multiple lines.
+
+    """
+
+    HELP = "Help attribute value."
+
+    class Config:
+        user = Option()
+
+
+class ComponentSubclass(ComponentBasic):
+    """A different docstring."""
+
+
+class ComponentOptionDefault:
+    class Config:
+        user = Option(default="ou812")
+
+
+class ComponentOptionDoc:
+    class Config:
+        user = Option(doc="ou812")
+
+
+class ComponentOptionDocMultiline:
+    class Config:
+        user = Option(doc="ou812")
+        password = Option(doc="First ``paragraph``.\n\nSecond paragraph.")
+
+
+class ComponentOptionDocDefault:
+    class Config:
+        user = Option(doc="This is some docs.", default="ou812")
+
+
+class Foo:
+    @classmethod
+    def parse_foo_class(cls, value):
+        pass
+
+    def parse_foo_instance(self, value):
+        pass
+
+
+class ComponentOptionParser:
+    class Config:
+        user_builtin = Option(parser=int)
+        user_parse_class = Option(parser=parse_class)
+        user_listof = Option(parser=ListOf(str))
+        user_class_method = Option(parser=Foo.parse_foo_class)
+        user_instance_method = Option(parser=Foo().parse_foo_instance)
+
+
+class ComponentWithDocstring:
+    """This component is the best.
+
+    The best!
+
+    """
+
+    class Config:
+        user = Option()
+
+
+class ComponentDocstringOtherAttribute:
+    """Programming-focused help"""
+
+    __everett_help__ = """
+        User-focused help
+    """
+
+    class Config:
+        user = Option()

--- a/tests/basic_module_config.py
+++ b/tests/basic_module_config.py
@@ -1,0 +1,23 @@
+"""Basic module config."""
+
+from everett.manager import ConfigManager
+
+
+_config = ConfigManager.from_dict(
+    {"debug": "False", "logging_level": "INFO", "password": "pwd", "fun": "0.0"}
+)
+
+
+def parse_logging_level(s: str) -> str:
+    if s not in ("CRITICAL", "WARNING", "INFO", "ERROR"):
+        raise ValueError("invalid logging level value")
+    return s
+
+
+DEBUG = _config(key="debug", parser=bool, default="False", doc="Debug mode.")
+
+LOGGING_LEVEL = _config(key="logging_level", parser=parse_logging_level, doc="Level.")
+
+PASSWORD = _config(key="password", doc="Password field.\n\nMust be provided.")
+
+FUN = _config(key="fun", parser=(int if 0 else float), doc="Woah.")

--- a/tests/simple_module_config.py
+++ b/tests/simple_module_config.py
@@ -1,0 +1,11 @@
+"""Simple module config."""
+
+from everett.manager import ConfigManager
+
+
+HELP = "Help attribute value."
+
+
+_config = ConfigManager.from_dict({"host": "localhost"})
+
+HOST = _config(key="host", default="localhost", doc="The host.")

--- a/tests/test_sphinxext.py
+++ b/tests/test_sphinxext.py
@@ -1,8 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Test sphinxext directives."""
+
+import sys
 from textwrap import dedent
 
+import pytest
 from sphinx.cmd.build import main as sphinx_main
-
-from everett.manager import ListOf, Option, parse_class
 
 
 def run_sphinx(docsdir, text, builder="text"):
@@ -51,19 +57,33 @@ def test_everett_component(tmpdir, capsys):
     # spitting out warnings
     rst = dedent(
         """\
-    .. everett:component:: test_sphinxext.ComponentDefaults
+    .. everett:component:: mymodule.ComponentBasic
 
-       :option str opt1: First option. Defaults to "foo".
+       .. everett:option:: opt1
+          :parser: str
+          :default: "foo"
+
+          First option.
 
     """
     )
 
     assert run_sphinx(tmpdir, rst) == dedent(
         """\
-        component test_sphinxext.ComponentDefaults
+        component mymodule.ComponentBasic
 
-           Options:
-              **opt1** (*str*) -- First option. Defaults to "foo".
+           opt1
+
+              Parser:
+                 *str*
+
+              Default:
+                 "foo"
+
+              Required:
+                 No
+
+              First option.
         """
     )
     captured = capsys.readouterr()
@@ -71,74 +91,88 @@ def test_everett_component(tmpdir, capsys):
     assert "WARNING" not in captured.err
 
 
-class ComponentDefaults:
-    class Config:
-        user = Option()
-
-
-def test_autocomponent_defaults(tmpdir):
-    rst = dedent(
-        """\
-    .. autocomponent:: test_sphinxext.ComponentDefaults
-    """
-    )
-
-    assert run_sphinx(tmpdir, rst) == dedent(
-        """\
-        component test_sphinxext.ComponentDefaults
-
-           Options:
-              **user** (*str*) --
-        """
-    )
-
-
-def test_hide_classname(tmpdir):
-    # Test classname
-    rst = dedent(
-        """\
-    .. autocomponent:: test_sphinxext.ComponentDefaults
-       :hide-classname:
-
-    """
-    )
-
-    assert run_sphinx(tmpdir, rst) == dedent(
-        """\
-        Configuration
-
-           Options:
-              **user** (*str*) --
-        """
-    )
-
-
-def test_namespace(tmpdir):
-    # Test namespace
-    rst = dedent(
-        """\
-    .. autocomponent:: test_sphinxext.ComponentDefaults
-       :namespace: foo
-
-    """
-    )
-
-    assert run_sphinx(tmpdir, rst) == dedent(
-        """\
-        component test_sphinxext.ComponentDefaults
-
-           Options:
-              **foo_user** (*str*) --
-        """
-    )
-
-
-class TestKeyCase:
-    # Test case
-    def test_bad_value(self, tmpdir):
+class Test_autocomponentconfig:
+    def test_basic(self, tmpdir, capsys):
         rst = dedent(
             """\
-        .. autocomponent:: test_sphinxext.ComponentDefaults
+        .. autocomponentconfig:: basic_component_config.ComponentBasic
+        """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component basic_component_config.ComponentBasic
+
+               user
+
+                  Parser:
+                     *str*
+
+                  Required:
+                     Yes
+            """
+        )
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "WARNING" not in captured.err
+
+    def test_hide_name(self, tmpdir, capsys):
+        # Test hide-name
+        rst = dedent(
+            """\
+        .. autocomponentconfig:: basic_component_config.ComponentBasic
+           :hide-name:
+
+        """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            Configuration
+
+               user
+
+                  Parser:
+                     *str*
+
+                  Required:
+                     Yes
+            """
+        )
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "WARNING" not in captured.err
+
+    def test_namespace(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+        .. autocomponentconfig:: basic_component_config.ComponentBasic
+           :namespace: foo
+
+        """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component basic_component_config.ComponentBasic
+
+               foo_user
+
+                  Parser:
+                     *str*
+
+                  Required:
+                     Yes
+            """
+        )
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "WARNING" not in captured.err
+
+    def test_case_bad_value(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+        .. autocomponentconfig:: basic_component_config.ComponentBasic
            :case: foo
 
         """
@@ -146,15 +180,14 @@ class TestKeyCase:
 
         # Because "foo" isn't valid, nothing ends up in the file
         assert run_sphinx(tmpdir, rst) == "\n"
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "argument must be \"upper\", \"lower\" or None." in captured.err
 
-        # FIXME(willkg): Verify an appropriate error was given to the user.
-        # It's hard to do since it comes via stderr, but we probalby have to
-        # find out where that code is and mock it directly.
-
-    def test_lower(self, tmpdir):
+    def test_case_lower(self, tmpdir, capsys):
         rst = dedent(
             """\
-        .. autocomponent:: test_sphinxext.ComponentDefaults
+        .. autocomponentconfig:: basic_component_config.ComponentBasic
            :case: lower
 
         """
@@ -162,17 +195,25 @@ class TestKeyCase:
 
         assert run_sphinx(tmpdir, rst) == dedent(
             """\
-            component test_sphinxext.ComponentDefaults
+            component basic_component_config.ComponentBasic
 
-               Options:
-                  **user** (*str*) --
+               user
+
+                  Parser:
+                     *str*
+
+                  Required:
+                     Yes
             """
         )
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "WARNING" not in captured.err
 
-    def test_upper(self, tmpdir):
+    def test_case_upper(self, tmpdir, capsys):
         rst = dedent(
             """\
-        .. autocomponent:: test_sphinxext.ComponentDefaults
+        .. autocomponentconfig:: basic_component_config.ComponentBasic
            :case: upper
 
         """
@@ -180,264 +221,693 @@ class TestKeyCase:
 
         assert run_sphinx(tmpdir, rst) == dedent(
             """\
-            component test_sphinxext.ComponentDefaults
+            component basic_component_config.ComponentBasic
 
-               Options:
-                  **USER** (*str*) --
+               USER
+
+                  Parser:
+                     *str*
+
+                  Required:
+                     Yes
+            """
+        )
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "WARNING" not in captured.err
+
+    def test_show_docstring_class_has_no_docstring(self, tmpdir, capsys):
+        # Test docstring-related things
+        rst = dedent(
+            """\
+            .. autocomponentconfig:: basic_component_config.ComponentBasic
+               :show-docstring:
+
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component basic_component_config.ComponentBasic
+
+               Basic component.
+
+               Multiple lines.
+
+               user
+
+                  Parser:
+                     *str*
+
+                  Required:
+                     Yes
+            """
+        )
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "WARNING" not in captured.err
+
+    def test_show_docstring(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. autocomponentconfig:: basic_component_config.ComponentWithDocstring
+               :show-docstring:
+
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component basic_component_config.ComponentWithDocstring
+
+               This component is the best.
+
+               The best!
+
+               user
+
+                  Parser:
+                     *str*
+
+                  Required:
+                     Yes
+            """
+        )
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "WARNING" not in captured.err
+
+    def test_show_docstring_other_attribute(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. autocomponentconfig:: basic_component_config.ComponentDocstringOtherAttribute
+               :show-docstring: __everett_help__
+
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component basic_component_config.ComponentDocstringOtherAttribute
+
+               User-focused help
+
+               user
+
+                  Parser:
+                     *str*
+
+                  Required:
+                     Yes
+            """
+        )
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "WARNING" not in captured.err
+
+    def test_show_docstring_subclass(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. autocomponentconfig:: basic_component_config.ComponentSubclass
+               :show-docstring:
+
+        """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component basic_component_config.ComponentSubclass
+
+               A different docstring.
+
+               user
+
+                  Parser:
+                     *str*
+
+                  Required:
+                     Yes
+            """
+        )
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "WARNING" not in captured.err
+
+    def test_option_default(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. autocomponentconfig:: basic_component_config.ComponentOptionDefault
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component basic_component_config.ComponentOptionDefault
+
+               user
+
+                  Parser:
+                     *str*
+
+                  Default:
+                     "ou812"
+
+                  Required:
+                     No
+            """
+        )
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "WARNING" not in captured.err
+
+    def test_option_doc(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. autocomponentconfig:: basic_component_config.ComponentOptionDoc
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component basic_component_config.ComponentOptionDoc
+
+               user
+
+                  Parser:
+                     *str*
+
+                  Required:
+                     Yes
+
+                  ou812
+            """
+        )
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "WARNING" not in captured.err
+
+    def test_option_doc_multiline(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. autocomponentconfig:: basic_component_config.ComponentOptionDocMultiline
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component basic_component_config.ComponentOptionDocMultiline
+
+               user
+
+                  Parser:
+                     *str*
+
+                  Required:
+                     Yes
+
+                  ou812
+
+               password
+
+                  Parser:
+                     *str*
+
+                  Required:
+                     Yes
+
+                  First "paragraph".
+
+                  Second paragraph.
+            """
+        )
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "WARNING" not in captured.err
+
+    def test_option_doc_default(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. autocomponentconfig:: basic_component_config.ComponentOptionDocDefault
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component basic_component_config.ComponentOptionDocDefault
+
+               user
+
+                  Parser:
+                     *str*
+
+                  Default:
+                     "ou812"
+
+                  Required:
+                     No
+
+                  This is some docs.
+            """
+        )
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "WARNING" not in captured.err
+
+    def test_option_parser(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. autocomponentconfig:: basic_component_config.ComponentOptionParser
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component basic_component_config.ComponentOptionParser
+
+               user_builtin
+
+                  Parser:
+                     *int*
+
+                  Required:
+                     Yes
+
+               user_parse_class
+
+                  Parser:
+                     *everett.manager.parse_class*
+
+                  Required:
+                     Yes
+
+               user_listof
+
+                  Parser:
+                     *<ListOf(str)>*
+
+                  Required:
+                     Yes
+
+               user_class_method
+
+                  Parser:
+                     *basic_component_config.Foo.parse_foo_class*
+
+                  Required:
+                     Yes
+
+               user_instance_method
+
+                  Parser:
+                     *basic_component_config.Foo.parse_foo_instance*
+
+                  Required:
+                     Yes
+            """
+        )
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "WARNING" not in captured.err
+
+
+@pytest.mark.skipif(
+    # NOTE(willkg): The automodule stuff doesn't work with Python < 3.8 because
+    # ast.get_source_segment() isn't available.
+    sys.version_info < (3, 8),
+    reason="requires Python 3.8 or higher",
+)
+class Test_automoduleconfig:
+    def test_basic(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. automoduleconfig:: basic_module_config._config
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component basic_module_config._config
+
+               debug
+
+                  Parser:
+                     *bool*
+
+                  Default:
+                     "False"
+
+                  Required:
+                     No
+
+                  Debug mode.
+
+               logging_level
+
+                  Parser:
+                     *parse_logging_level*
+
+                  Required:
+                     Yes
+
+                  Level.
+
+               password
+
+                  Parser:
+                     *str*
+
+                  Required:
+                     Yes
+
+                  Password field.
+
+                  Must be provided.
+
+               fun
+
+                  Parser:
+                     *int if 0 else float*
+
+                  Required:
+                     Yes
+
+                  Woah.
+            """
+        )
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "WARNING" not in captured.err
+
+    def test_hide_name(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. automoduleconfig:: simple_module_config._config
+               :hide-name:
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            Configuration
+
+               host
+
+                  Parser:
+                     *str*
+
+                  Default:
+                     "localhost"
+
+                  Required:
+                     No
+
+                  The host.
+            """
+        )
+
+    def test_namespace(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. automoduleconfig:: simple_module_config._config
+               :namespace: app
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component simple_module_config._config
+
+               app_host
+
+                  Parser:
+                     *str*
+
+                  Default:
+                     "localhost"
+
+                  Required:
+                     No
+
+                  The host.
+            """
+        )
+
+    def test_case_upper(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. automoduleconfig:: simple_module_config._config
+               :case: upper
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component simple_module_config._config
+
+               HOST
+
+                  Parser:
+                     *str*
+
+                  Default:
+                     "localhost"
+
+                  Required:
+                     No
+
+                  The host.
+            """
+        )
+
+    def test_case_lower(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. automoduleconfig:: simple_module_config._config
+               :case: lower
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component simple_module_config._config
+
+               host
+
+                  Parser:
+                     *str*
+
+                  Default:
+                     "localhost"
+
+                  Required:
+                     No
+
+                  The host.
+            """
+        )
+
+    def test_show_table(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. automoduleconfig:: simple_module_config._config
+               :show-table:
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component simple_module_config._config
+
+               Configuration summary:
+
+               +--------------------------------------------------------------+----------+-------------+
+               | Setting                                                      | Parser   | Required?   |
+               |==============================================================|==========|=============|
+               | "host"                                                       | *str*    |             |
+               +--------------------------------------------------------------+----------+-------------+
+
+               Configuration options:
+
+               host
+
+                  Parser:
+                     *str*
+
+                  Default:
+                     "localhost"
+
+                  Required:
+                     No
+
+                  The host.
+            """
+        )
+
+    def test_show_docstring(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. automoduleconfig:: simple_module_config._config
+               :show-docstring:
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component simple_module_config._config
+
+               Simple module config.
+
+               host
+
+                  Parser:
+                     *str*
+
+                  Default:
+                     "localhost"
+
+                  Required:
+                     No
+
+                  The host.
+            """
+        )
+
+    def test_show_docstring_by_attribute(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. automoduleconfig:: simple_module_config._config
+               :show-docstring: HELP
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component simple_module_config._config
+
+               Help attribute value.
+
+               host
+
+                  Parser:
+                     *str*
+
+                  Default:
+                     "localhost"
+
+                  Required:
+                     No
+
+                  The host.
             """
         )
 
 
-def test_show_docstring_class_has_no_docstring(tmpdir):
-    # Test docstring-related things
-    rst = dedent(
-        """\
-    .. autocomponent:: test_sphinxext.ComponentDefaults
-       :show-docstring:
-
-    """
-    )
-
-    assert run_sphinx(tmpdir, rst) == dedent(
-        """\
-        component test_sphinxext.ComponentDefaults
-
-           Options:
-              **user** (*str*) --
-        """
-    )
-
-
-class ComponentWithDocstring:
-    """This component is the best.
-
-    The best!
-
-    """
-
-    class Config:
-        user = Option()
-
-
-def test_show_docstring(tmpdir):
-    rst = dedent(
-        """\
-    .. autocomponent:: test_sphinxext.ComponentWithDocstring
-       :show-docstring:
-
-    """
-    )
-
-    assert run_sphinx(tmpdir, rst) == dedent(
-        """\
-        component test_sphinxext.ComponentWithDocstring
-
-           This component is the best.
-
-           The best!
-
-           Options:
-              **user** (*str*) --
-        """
-    )
-
-
-class ComponentDocstringOtherAttribute:
-    """Programming-focused help"""
-
-    __everett_help__ = """
-        User-focused help
-    """
-
-    class Config:
-        user = Option()
-
-
-def test_show_docstring_other_attribute(tmpdir):
-    rst = dedent(
-        """\
-    .. autocomponent:: test_sphinxext.ComponentDocstringOtherAttribute
-       :show-docstring: __everett_help__
-
-    """
-    )
-
-    assert run_sphinx(tmpdir, rst) == dedent(
-        """\
-        component test_sphinxext.ComponentDocstringOtherAttribute
-
-           User-focused help
-
-           Options:
-              **user** (*str*) --
-        """
-    )
-
-
-class ComponentSubclass(ComponentWithDocstring):
-    """A different docstring"""
-
-
-def test_show_docstring_subclass(tmpdir):
-    rst = dedent(
-        """\
-    .. autocomponent:: test_sphinxext.ComponentSubclass
-       :show-docstring:
-
-    """
-    )
-
-    assert run_sphinx(tmpdir, rst) == dedent(
-        """\
-        component test_sphinxext.ComponentSubclass
-
-           A different docstring
-
-           Options:
-              **user** (*str*) --
-        """
-    )
-
-
-class ComponentOptionDefault:
-    class Config:
-        user = Option(default="ou812")
-
-
-def test_option_default(tmpdir):
-    rst = dedent(
-        """\
-    .. autocomponent:: test_sphinxext.ComponentOptionDefault
-    """
-    )
-
-    assert run_sphinx(tmpdir, rst) == dedent(
-        """\
-        component test_sphinxext.ComponentOptionDefault
-
-           Options:
-              **user** (*str*) -- Defaults to "\'ou812\'".
-        """
-    )
-
-
-class ComponentOptionDoc:
-    class Config:
-        user = Option(doc="ou812")
-
-
-def test_option_doc(tmpdir):
-    rst = dedent(
-        """\
-    .. autocomponent:: test_sphinxext.ComponentOptionDoc
-    """
-    )
-
-    assert run_sphinx(tmpdir, rst) == dedent(
-        """\
-        component test_sphinxext.ComponentOptionDoc
-
-           Options:
-              **user** (*str*) -- ou812
-        """
-    )
-
-
-class ComponentOptionDocMultiline:
-    class Config:
-        user = Option(doc="ou812")
-        password = Option(doc="First ``paragraph``.\n\nSecond paragraph.")
-
-
-def test_option_doc_multiline(tmpdir):
-    rst = dedent(
-        """\
-    .. autocomponent:: test_sphinxext.ComponentOptionDocMultiline
-    """
-    )
-
-    assert run_sphinx(tmpdir, rst) == dedent(
-        """\
-        component test_sphinxext.ComponentOptionDocMultiline
-
-           Options:
-              * **user** (*str*) -- ou812
-
-              * **password** (*str*) --
-
-                First "paragraph".
-
-                Second paragraph.
-        """
-    )
-
-
-class ComponentOptionDocDefault:
-    class Config:
-        user = Option(doc="This is some docs.", default="ou812")
-
-
-def test_option_doc_default(tmpdir):
-    rst = dedent(
-        """\
-    .. autocomponent:: test_sphinxext.ComponentOptionDocDefault
-    """
-    )
-
-    assert run_sphinx(tmpdir, rst) == dedent(
-        """\
-        component test_sphinxext.ComponentOptionDocDefault
-
-           Options:
-              **user** (*str*) --
-
-              This is some docs.
-
-              Defaults to "\'ou812\'".
-        """
-    )
-
-
-class Foo:
-    @classmethod
-    def parse_foo_class(cls, value):
-        pass
-
-    def parse_foo_instance(self, value):
-        pass
-
-
-class ComponentOptionParser:
-    class Config:
-        user_builtin = Option(parser=int)
-        user_parse_class = Option(parser=parse_class)
-        user_listof = Option(parser=ListOf(str))
-        user_class_method = Option(parser=Foo.parse_foo_class)
-        user_instance_method = Option(parser=Foo().parse_foo_instance)
-
-
-def test_option_parser(tmpdir):
-    rst = dedent(
-        """\
-    .. autocomponent:: test_sphinxext.ComponentOptionParser
-    """
-    )
-
-    assert run_sphinx(tmpdir, rst) == dedent(
-        """\
-        component test_sphinxext.ComponentOptionParser
-
-           Options:
-              * **user_builtin** (*int*) --
-
-              * **user_parse_class** (*everett.manager.parse_class*) --
-
-              * **user_listof** (*<ListOf(str)>*) --
-
-              * **user_class_method** (*test_sphinxext.Foo.parse_foo_class*)
-                --
-
-              * **user_instance_method**
-                (*test_sphinxext.Foo.parse_foo_instance*) --
-        """
-    )
+class Test_everett_option:
+    def test_basic(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. everett:option:: debug
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            debug
+
+               Parser:
+                  *str*
+
+               Required:
+                  Yes
+            """
+        )
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "WARNING" not in captured.err
+
+    def test_thorough(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. everett:option:: debug
+               :parser: bool
+               :default: "false"
+
+               Set to "true" for debug mode
+            """
+        )
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            debug
+
+               Parser:
+                  *bool*
+
+               Default:
+                  "false"
+
+               Required:
+                  No
+
+               Set to "true" for debug mode
+            """
+        )
+
+    def test_no_default_means_required(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. everett:option:: debug
+               :parser: bool
+
+               Set to "true" for debug mode
+            """
+        )
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            debug
+
+               Parser:
+                  *bool*
+
+               Required:
+                  Yes
+
+               Set to "true" for debug mode
+            """
+        )
+
+
+class Test_everett_component:
+    def test_basic(self, tmpdir, capsys):
+        rst = dedent(
+            """\
+            .. everett:component:: MyClass
+
+               Some details about my class.
+
+               .. everett:option:: debug
+                  :parser: bool
+
+                  Set to "true" for debug mode
+            """
+        )
+
+        assert run_sphinx(tmpdir, rst) == dedent(
+            """\
+            component MyClass
+
+               Some details about my class.
+
+               debug
+
+                  Parser:
+                     *bool*
+
+                  Required:
+                     Yes
+
+                  Set to "true" for debug mode
+            """
+        )
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.out
+        assert "WARNING" not in captured.err

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py37-lint,py38-typecheck
+envlist = py37,py38,py39,py310,py37-doctest,py37-flake7,py37-black,py38-typecheck
 
 [gh-actions]
 python =
@@ -11,16 +11,22 @@ python =
 [testenv]
 install_command = pip install {packages}
 extras = dev,ini,yaml
-commands =
-    pytest tests/
-    pytest --doctest-modules src/
+commands = {posargs:pytest tests/}
 
-[testenv:py37-lint]
+[testenv:py37-doctest]
+install_command = pip install {packages}
+extras = dev,ini,yaml
+commands = pytest --doctest-modules src/
+
+[testenv:py37-black]
 basepython = python3.7
 changedir = {toxinidir}
-commands =
-    black --check --target-version=py37 --line-length=88 src tests
-    flake8 src tests
+commands = black --check --target-version=py37 --line-length=88 src tests
+
+[testenv:py37-flake8]
+basepython = python3.7
+changedir = {toxinidir}
+commands = flake8 src tests
 
 [testenv:py38-typecheck]
 basepython = python3.8


### PR DESCRIPTION
This overhauls the Sphinx extension.

This now supports manually documenting configuration using
``everett:component`` and ``everett:option`` directives.

This adds ``:everett:component:`` and ``:everett:option:`` roles for
linking to specific configuration in the docs.

It also addsh ``autocomponentconfig`` and ``automoduleconfig``
directives for automatically generating documentation.

When using these directives, items are added to the index and everything
is linkable making it easier to find and talk to users about specific
configuration items.

Fixes #172.