### PR TITLE
Update for Python 3.11.0 (#187)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     name: Python ${{ matrix.python-version}}
     steps:
@@ -24,10 +24,7 @@ jobs:
       - name: Update pip and install dev requirements
         run: |
           python -m pip install --upgrade pip
-          pip install '.[dev,datadog.statsd]'
-
-      - name: Lint
-        run: make lint
+          pip install -r requirements-dev.txt
 
       - name: Test
         run: tox

--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,14 @@ help:
 	@fgrep -h "##" Makefile | fgrep -v fgrep | sed 's/\(.*\):.*##/\1:  /'
 
 .PHONY: test
-test:  ## Run tests and static typechecking
+test:  ## Run tests, linting, and static typechecking
 	tox
-
-.PHONY: typecheck
-typecheck:  ## Run typechecking (requires Python 3.8)
-	mypy src/everett/
 
 .PHONY: lint
 lint:  ## Lint and black reformat files
+	# NOTE(willkg): Make sure this matches what's in tox.ini.
 	black --target-version=py37 --line-length=88 src setup.py tests docs examples
-	flake8 src tests examples
+	tox -e py37-flake8
 
 .PHONY: clean
 clean:  ## Clean build artifacts
@@ -40,6 +37,6 @@ docs:  ## Runs cog and builds Sphinx docs
 checkrot:  ## Check package rot for dev dependencies
 	python -m venv ./tmpvenv/
 	./tmpvenv/bin/pip install -U pip
-	./tmpvenv/bin/pip install '.[dev,ini,yaml]'
+	./tmpvenv/bin/pip install -r requirements-dev.txt
 	./tmpvenv/bin/pip list -o
 	rm -rf ./tmpvenv/

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -14,7 +14,7 @@ Run::
     $ mkvirtualenv everett
 
     # Install Everett and dev requirements
-    $ pip install -e '.[dev,ini,yaml]'
+    $ pip install -r requirements-dev.txt
 
 
 Release process

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 # NOTE: this gets run during the RTD build from the parent directory with:
 # python -m pip install --exists-action=w --no-cache-dir -r docs/requirements.txt
--e .[dev,ini,yaml]
+-r requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,14 @@
+# Requirements file for developing on Everett.
+-e .[ini,yaml]
+
+black==22.10.0
+check-manifest==0.48
+cogapp==3.3.0
+mypy==0.982
+pytest==7.2.0
+Sphinx==5.3.0
+sphinx_rtd_theme==1.0.0
+tox==3.26.0
+tox-gh-actions==2.10.0
+twine==4.0.1
+types-PyYAML==6.0.12

--- a/requirements-flake8.txt
+++ b/requirements-flake8.txt
@@ -1,0 +1,3 @@
+# Requirements file for running flake8.
+
+flake8==5.0.4

--- a/setup.py
+++ b/setup.py
@@ -26,20 +26,6 @@ INSTALL_REQUIRES = []
 EXTRAS_REQUIRE = {
     "ini": ["configobj"],
     "yaml": ["PyYAML"],
-    "dev": [
-        "black==20.8b1",
-        "check-manifest==0.47",
-        "cogapp==3.3.0",
-        "flake8==4.0.1",
-        "mypy==0.931",
-        "pytest==6.2.5",
-        "Sphinx==4.3.2",
-        "sphinx_rtd_theme==1.0.0",
-        "tox==3.24.5",
-        "tox-gh-actions==2.9.1",
-        "twine==3.7.1",
-        "types-PyYAML==6.0.3",
-    ],
 }
 
 
@@ -69,6 +55,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     project_urls={
         "Documentation": "https://everett.readthedocs.io/",

--- a/src/everett/sphinxext.py
+++ b/src/everett/sphinxext.py
@@ -154,7 +154,10 @@ class EverettOption(ObjectDescription):
             objects[key] = (self.env.docname, targetname)
 
         indextext = _("%s (component)") % name
-        self.indexnode["entries"].append(("single", indextext, targetname, "", None))
+        if self.indexnode is not None:
+            self.indexnode["entries"].append(
+                ("single", indextext, targetname, "", None)
+            )
 
     def transform_content(self, contentnode: addnodes.desc_content) -> None:
         # We want to insert some stuff before the content
@@ -247,7 +250,10 @@ class EverettComponent(ObjectDescription):
             objects[key] = (self.env.docname, targetname)
 
         indextext = _("%s (component)") % name
-        self.indexnode["entries"].append(("single", indextext, targetname, "", None))
+        if self.indexnode is not None:
+            self.indexnode["entries"].append(
+                ("single", indextext, targetname, "", None)
+            )
 
     def before_content(self) -> None:
         if self.names:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py37-doctest,py37-flake7,py37-black,py38-typecheck
+envlist = py37,py38,py39,py310,py311,py37-doctest,py37-flake8,py37-black,py38-typecheck
 
 [gh-actions]
 python =
@@ -7,23 +7,25 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
-install_command = pip install {packages}
-extras = dev,ini,yaml
+deps = -rrequirements-dev.txt
 commands = {posargs:pytest tests/}
 
 [testenv:py37-doctest]
-install_command = pip install {packages}
-extras = dev,ini,yaml
+deps = -rrequirements-dev.txt
 commands = pytest --doctest-modules src/
 
 [testenv:py37-black]
 basepython = python3.7
 changedir = {toxinidir}
-commands = black --check --target-version=py37 --line-length=88 src tests
+commands = black --check --target-version=py37 --line-length=88 src setup.py tests docs examples
 
 [testenv:py37-flake8]
+# flake8 pins importlib_metadata for reasons and there's a lot of anger and
+# emotion involved. We run this in a different environment.
+deps = -rrequirements-flake8.txt
 basepython = python3.7
 changedir = {toxinidir}
 commands = flake8 src tests


### PR DESCRIPTION
This adds Python 3.11 to the Python versions that are tested. It adds the trover classifier.

This also redoes how dev dependencies are specified, updates them, fixes issues with flake8 and Sphinx having conflicting requirements for `importlib_metadata`, and centralizes some duplicate instructions into `tox.ini`.

This also fixes some mypy typechecking issues in `src/everett/sphinxext.py`.

Fixes #187.