### PR TITLE
Fix rtd to install requirements (#186)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,3 +15,8 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
+
+# Install dev requirements so that the documentation can build correctly
+python:
+  install:
+    - requirements: requirements-dev.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,0 @@
-# NOTE: this gets run during the RTD build from the parent directory with:
-# python -m pip install --exists-action=w --no-cache-dir -r docs/requirements.txt
--r requirements-dev.txt


### PR DESCRIPTION
From the build logs, it looks like ReadTheDocs isn't installing the requirements and thus several directives aren't being documented.