### PR TITLE
Add raise_configuration_error convenience method (#185)

### DIFF
--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -405,14 +405,22 @@ def test_config():
     )
 
 
+def test_raise_configuration_error():
+    config = ConfigManager.from_dict({"foo_bar": "bat"})
+    config.doc = "Check https://example.com/configuration for documentation."
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        config.raise_configuration_error("This is an error")
+    assert str(excinfo.value) == "This is an error\nProject docs: " + config.doc
+
+
 def test_invalidvalueerror():
     config = ConfigManager.from_dict({"foo_bar": "bat"})
     with pytest.raises(InvalidValueError) as excinfo:
         config("bar", namespace="foo", parser=bool)
-
-        assert excinfo.value.namespace == "foo"
-        assert excinfo.value.key == "bar"
-        assert excinfo.value.parser == bool
+    assert excinfo.value.namespace == ["foo"]
+    assert excinfo.value.key == "bar"
+    assert excinfo.value.parser == parse_bool
 
 
 def test_configurationmissingerror():


### PR DESCRIPTION
This adds a `raise_configuration_error` convenience method to `ConfigManager` making it easier for developers to raise a configuration error that will pick up the configuration documentation in the message. This is useful for cases where the application needs to validate values of configuration options that are connected.

For example, if you want to require the user to either set the host and port or neither, you can validate it and use `raise_configuration_error` if the user does something you didn't want.

Fixes #185.