### PR TITLE
Support dicts and nested configuration (#184)

### DIFF
--- a/examples/recipes_djangosettings.py
+++ b/examples/recipes_djangosettings.py
@@ -9,3 +9,23 @@ _config = ConfigManager.basic_config()
 DEBUG = _config(
     "debug", parser=bool, default="False", doc="Whether or not DEBUG mode is enabled."
 )
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+        "LOCATION": _config(
+            "cache_location", default="127.0.0.1:11211", doc="Memcache cache location."
+        ),
+        "TIMEOUT": _config(
+            "cache_timeout",
+            default="500",
+            parser=int,
+            doc="Timeout to use when accessing cache.",
+        ),
+        "KEY_PREFIX": _config(
+            "cache_key_prefix",
+            default="socorro",
+            doc="Key prefix to use for all cache keys.",
+        ),
+    }
+}

--- a/tests/basic_module_config.py
+++ b/tests/basic_module_config.py
@@ -21,3 +21,12 @@ LOGGING_LEVEL = _config(key="logging_level", parser=parse_logging_level, doc="Le
 PASSWORD = _config(key="password", doc="Password field.\n\nMust be provided.")
 
 FUN = _config(key="fun", parser=(int if 0 else float), doc="Woah.")
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+        "LOCATION": _config(
+            "cache_location", default="127.0.0.1:11211", doc="The location"
+        ),
+    }
+}

--- a/tests/test_sphinxext.py
+++ b/tests/test_sphinxext.py
@@ -592,10 +592,25 @@ class Test_automoduleconfig:
                      Yes
 
                   Woah.
+
+               cache_location
+
+                  Parser:
+                     *str*
+
+                  Default:
+                     "127.0.0.1:11211"
+
+                  Required:
+                     No
+
+                  The location
             """
         )
         captured = capsys.readouterr()
+        print(captured.out)
         assert "WARNING" not in captured.out
+        print(captured.err)
         assert "WARNING" not in captured.err
 
     def test_hide_name(self, tmpdir, capsys):


### PR DESCRIPTION
This adds support for configuration being set in the module other than in the top level. This also adds support for configuration being called in dict contexts.

Now you can do something like this:

```
_config = ConfigManager.basic_config()

CACHES = {
    "default": {
        "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
        "LOCATION": _config("CACHE_LOCATION", default="127.0.0.1:11211"),
        "TIMEOUT": _config("CACHE_TIMEOUT", default="500", parser=int),
        "KEY_PREFIX": _config("CACHE_KEY_PREFIX", default="socorro"),
    }
}
```

Then in your docs, use `automoduleconfig` and it'll pick up `CACHE_LOCATION`, `CACHE_TIMEOUT`, and `CACHE_KEY_PREFIX` options.