### PR TITLE
Implement default_if_unset argument (#205)

### DIFF
--- a/src/everett/manager.py
+++ b/src/everett/manager.py
@@ -1063,6 +1063,7 @@ class ConfigManager:
         key: str,
         namespace: Union[List[str], str, None] = None,
         default: Union[str, NoValue] = NO_VALUE,
+        default_if_unset: bool = True,
         alternate_keys: Optional[List[str]] = None,
         doc: str = "",
         parser: Callable = str,
@@ -1083,6 +1084,9 @@ class ConfigManager:
 
             If this ConfigManager is bound to a component, the default will be
             the default of the option in the bound component configuration.
+
+        :param default_if_unset: if True, treat empty string values as a
+            non-value and use the default if specified
 
         :param alternate_keys: the list of alternate keys to look up;
             supports a ``root:`` key prefix which will cause this to look at
@@ -1188,6 +1192,11 @@ class ConfigManager:
             # Go through environments in reverse order
             for env in self.envs:
                 val = env.get(possible_key, use_namespace)
+
+                # If the value is the empty string and default_if_unset, treat
+                # it as a non-value
+                if val == "" and default_if_unset:
+                    val = NO_VALUE
 
                 if val is not NO_VALUE:
                     try:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -519,6 +519,14 @@ def test_default_must_be_string():
         assert config("DOESNOTEXIST", default=True)
 
 
+def test_default_if_unset():
+    config = ConfigManager.from_dict({"FOO": ""})
+
+    assert config("FOO", default="5", parser=int) == 5
+    with pytest.raises(InvalidValueError):
+        assert config("FOO", default="5", parser=int, default_if_unset=False)
+
+
 def test_with_namespace():
     config = ConfigManager(
         [ConfigDictEnv({"FOO_BAR": "foobaz", "BAR": "baz", "BAT": "bat"})]


### PR DESCRIPTION
If the value is the empty string, we want to determine whether to treat that as a non-value or a valid value. This adds default_if_unset to handle that.