### PR TITLE
Add parse_data_size (#204)

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -38,6 +38,7 @@ Parsers:
 
 * :py:func:`everett.manager.parse_bool`
 * :py:func:`everett.manager.parse_class`
+* :py:func:`everett.manager.parse_data_size`
 * :py:func:`everett.manager.ListOf`
 
 

--- a/docs/parsers.rst
+++ b/docs/parsers.rst
@@ -78,6 +78,17 @@ specifying a module and class and returns the class.
    :noindex:
 
 
+data size
+----------
+
+Everett provides a ``everett.manager.parse_data_size`` that takes a string
+specifying an amount and a data size metric (e.g. kb, kib, tb, etc) and returns
+the amount of bytes that represents.
+
+.. autofunction:: everett.manager.parse_data_size
+   :noindex:
+
+
 ListOf(parser)
 --------------
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -31,6 +31,7 @@ from everett.manager import (
     listify,
     parse_bool,
     parse_class,
+    parse_data_size,
     parse_env_file,
     qualname,
 )
@@ -180,6 +181,28 @@ def test_parse_class():
     from hashlib import md5
 
     assert parse_class("hashlib.md5") == md5
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("0", 0),
+        # decimal
+        ("10b", 10),
+        ("1kb", 1_000),
+        ("10kb", 10_000),
+        ("5mb", 5_000_000),
+        ("7gb", 7_000_000_000),
+        ("32tb", 32_000_000_000_000),
+        # binary
+        ("10kib", 10_240),
+        ("2MiB", 2_097_152),
+        ("17gib", 18_253_611_008),
+        ("4tib", 4_398_046_511_104),
+    ],
+)
+def test_parse_data_size(text, expected):
+    assert parse_data_size(text) == expected
 
 
 def test_parse_class_config():


### PR DESCRIPTION
This adds a parse_data_size parser which takes a string containing an amount and a metric and returns the number of bytes that represents as an integer. For example, 10kb would be 10_000.

Fixes #204 