### PR TITLE
Add parse_time_period (#203)

### DIFF
--- a/docs/parsers.rst
+++ b/docs/parsers.rst
@@ -79,11 +79,22 @@ specifying a module and class and returns the class.
 
 
 data size
-----------
+---------
 
 Everett provides a ``everett.manager.parse_data_size`` that takes a string
 specifying an amount and a data size metric (e.g. kb, kib, tb, etc) and returns
 the amount of bytes that represents.
+
+.. autofunction:: everett.manager.parse_data_size
+   :noindex:
+
+
+time period
+-----------
+
+Everett provides a ``everett.manager.parse_time_period`` that takes a string
+specifying a period of time and returns the total number of seconds represented
+by that period.
 
 .. autofunction:: everett.manager.parse_data_size
    :noindex:

--- a/src/everett/manager.py
+++ b/src/everett/manager.py
@@ -358,7 +358,7 @@ _DATA_SIZE_METRIC_TO_MULTIPLIER = {
     "tib": pow(1_024, 4),
 }
 _DATA_SIZE_RE = re.compile(
-    r"^([0-9]+)(" + "|".join(_DATA_SIZE_METRIC_TO_MULTIPLIER.keys()) + ")?$"
+    r"^([0-9_]+)(" + "|".join(_DATA_SIZE_METRIC_TO_MULTIPLIER.keys()) + ")?$"
 )
 
 
@@ -391,13 +391,21 @@ def parse_data_size(val: str) -> Any:
     The metrics are not case sensitive--it supports upper, lower, and mixed case.
 
     >>> from everett.manager import parse_data_size
+    >>> parse_data_size("40_000_000")
+    40000000
     >>> parse_data_size("40gb")
     40000000000
     >>> parse_data_size("20KiB")
     20480
 
     """
-    match = _DATA_SIZE_RE.match(val.lower().strip())
+    fixed_val = val.lower().strip()
+    try:
+        return int(fixed_val)
+    except ValueError:
+        pass
+
+    match = _DATA_SIZE_RE.match(fixed_val)
     if not match:
         raise ValueError(f"{val!r} is not a valid data size")
     amount, metric = match.groups()
@@ -411,7 +419,7 @@ _TIME_UNIT_TO_MULTIPLIER = {
     "m": 60,
     "s": 1,
 }
-_TIME_RE = re.compile(r"([0-9]+)([" + "".join(_TIME_UNIT_TO_MULTIPLIER.keys()) + r"])")
+_TIME_RE = re.compile(r"([0-9_]+)([" + "".join(_TIME_UNIT_TO_MULTIPLIER.keys()) + r"])")
 
 
 def parse_time_period(val: str) -> Any:
@@ -426,11 +434,21 @@ def parse_time_period(val: str) -> Any:
     * s - second
 
     >>> from everett.manager import parse_time_period
+    >>> parse_time_period("103")
+    103
+    >>> parse_time_period("1_000m")
+    60000
     >>> parse_time_period("15m4s")
     904
 
     """
-    parts = _TIME_RE.findall(val.lower().strip())
+    fixed_val = val.lower().strip()
+    try:
+        return int(fixed_val)
+    except ValueError:
+        pass
+
+    parts = _TIME_RE.findall(fixed_val)
     if not parts:
         raise ValueError(f"{val!r} is not a valid time period")
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -32,6 +32,7 @@ from everett.manager import (
     parse_bool,
     parse_class,
     parse_data_size,
+    parse_time_period,
     parse_env_file,
     qualname,
 )
@@ -189,6 +190,7 @@ def test_parse_class():
         ("0", 0),
         # decimal
         ("10b", 10),
+        ("  10b  ", 10),
         ("1kb", 1_000),
         ("10kb", 10_000),
         ("5mb", 5_000_000),
@@ -203,6 +205,33 @@ def test_parse_class():
 )
 def test_parse_data_size(text, expected):
     assert parse_data_size(text) == expected
+
+
+@pytest.mark.parametrize("text", ["", "gb", "15yy"])
+def test_parse_data_size_bad_values(text):
+    with pytest.raises(ValueError):
+        parse_data_size(text)
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("1s", 1),
+        ("10m", 600),
+        ("10m3s", 603),
+        ("1d10m", 87_000),
+        ("1w2d", 777_600),
+        ("  1w 2d  ", 777_600),
+    ],
+)
+def test_parse_time_period(text, expected):
+    assert parse_time_period(text) == expected
+
+
+@pytest.mark.parametrize("text", ["", "m", "10", "10j"])
+def test_parse_time_period_bad_values(text):
+    with pytest.raises(ValueError):
+        parse_time_period(text)
 
 
 def test_parse_class_config():

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -188,9 +188,11 @@ def test_parse_class():
     "text, expected",
     [
         ("0", 0),
+        ("1_000", 1_000),
         # decimal
         ("10b", 10),
         ("  10b  ", 10),
+        ("1_000b", 1_000),
         ("1kb", 1_000),
         ("10kb", 10_000),
         ("5mb", 5_000_000),
@@ -216,8 +218,11 @@ def test_parse_data_size_bad_values(text):
 @pytest.mark.parametrize(
     "text, expected",
     [
+        ("15", 15),
+        ("1_000", 1_000),
         ("1s", 1),
         ("10m", 600),
+        ("1_000m", 60_000),
         ("10m3s", 603),
         ("1d10m", 87_000),
         ("1w2d", 777_600),
@@ -228,7 +233,7 @@ def test_parse_time_period(text, expected):
     assert parse_time_period(text) == expected
 
 
-@pytest.mark.parametrize("text", ["", "m", "10", "10j"])
+@pytest.mark.parametrize("text", ["", "m", "10j"])
 def test_parse_time_period_bad_values(text):
     with pytest.raises(ValueError):
         parse_time_period(text)


### PR DESCRIPTION
This adds a parse_time_period parse for handling time periods like 10m. It returns the total number of seconds represented by the value.

While doing this, I fixed some issues with parse_data_size, too.

Fixes #203 