### PR TITLE
Support _ as the first character in environment variables

### DIFF
--- a/src/everett/manager.py
+++ b/src/everett/manager.py
@@ -60,7 +60,7 @@ __all__ = [
 
 
 # Regex for valid keys in an env file
-ENV_KEY_RE = re.compile(r"^[a-z][a-z0-9_]*$", flags=re.IGNORECASE)
+ENV_KEY_RE = re.compile(r"^[a-z_][a-z0-9_]*$", flags=re.IGNORECASE)
 
 logger = logging.getLogger("everett")
 


### PR DESCRIPTION
This updates the validation regex to allow keys in an env file to start with an underscore.

I just noticed this in conflict with an env var `_TYPER_STANDARD_TRACEBACK`. This [SO](https://stackoverflow.com/questions/2821043/allowed-characters-in-linux-environment-variable-names) post seems to have a pretty valid answer sourcing this document about this https://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html