### PR TITLE
Update sphinx to recent version

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.8"
+    python: "3.9"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,6 @@ tox-gh-actions==3.1.3
 twine==4.0.2
 types-PyYAML==6.0.12.12
 
-# We need to drop support for Python 3.8 before we can update this further.
-Sphinx==6.2.1
+Sphinx==7.2.6; python_version > "3.8"
+Sphinx==6.2.1; python_version <= "3.8"
 sphinx_rtd_theme==1.3.0


### PR DESCRIPTION
Everett still supports Python 3.8, so for Python 3.8, we install an older version.