### PR TITLE
Support runtime concatenation of description strings (#240)

### DIFF
--- a/src/everett/sphinxext.py
+++ b/src/everett/sphinxext.py
@@ -732,6 +732,10 @@ class AutoModuleConfigDirective(ConfigDirective):
                 return "constant", val.value
             if isinstance(val, ast.Name):
                 return "name", val.id
+            if isinstance(val, ast.BinOp) and isinstance(val.op, ast.Add):
+                _, left = extract_value(source, val.left)
+                _, right = extract_value(source, val.right)
+                return "binop", left + right
             return "unknown", get_value_from_ast_node(source, val)
 
         # Using a dict here avoids the case where configuration options are

--- a/tests/basic_module_config.py
+++ b/tests/basic_module_config.py
@@ -30,3 +30,13 @@ CACHES = {
         ),
     }
 }
+
+LONG_DESC = _config(
+    key="long_description",
+    default="",
+    doc=(
+        "This configuration item has a really long description that spans "
+        + "several lines so we can test runtime string concatenation.\n\n"
+        + "Multiple lines should work, too."
+    ),
+)

--- a/tests/test_sphinxext.py
+++ b/tests/test_sphinxext.py
@@ -593,6 +593,22 @@ class Test_automoduleconfig:
 
                   Woah.
 
+               long_description
+
+                  Parser:
+                     *str*
+
+                  Default:
+                     ""
+
+                  Required:
+                     No
+
+                  This configuration item has a really long description that spans
+                  several lines so we can test runtime string concatenation.
+
+                  Multiple lines should work, too.
+
                cache_location
 
                   Parser:


### PR DESCRIPTION
This fixes automoduleconfig so this works:

```
DESC = _config(
    "somekey",
    doc=(
        "This is a really long multi-line comment "
        + "that uses runtime string concatenation."
    )
)
```

Fixes #240